### PR TITLE
Show track tags and mentions on r4-track

### DIFF
--- a/examples/r4-channel/index.html
+++ b/examples/r4-channel/index.html
@@ -23,7 +23,7 @@
 	</menu>
 	<r4-channel></r4-channel>
 	<r4-channel-actions></r4-channel-actions>
-	<r4-tracks channel=""></r4-tracks>
+	<r4-tracks limit="2000" channel=""></r4-tracks>
 </body>
 
 <script>
@@ -36,7 +36,6 @@
 
 	const $channelTracks = document.querySelector('r4-tracks')
 	slug && $channelTracks.setAttribute('channel', slug)
-
 
 	/* add some actions to the channel */
 	const onChannelInput = ({ detail }) => {

--- a/src/components/r4-track.js
+++ b/src/components/r4-track.js
@@ -67,7 +67,7 @@ export default class R4Channel extends HTMLElement {
 			<small>
 				${t.tags}
 				${t.mentions}
-			</small></article>
+			</small>
 		`, $track)
 		this.append($track)
 	}

--- a/src/components/r4-track.js
+++ b/src/components/r4-track.js
@@ -1,4 +1,5 @@
 import {readTrack} from '@radio4000/sdk'
+import { html, render } from 'lit-html'
 
 export default class R4Channel extends HTMLElement {
 	static get observedAttributes() {
@@ -58,9 +59,17 @@ export default class R4Channel extends HTMLElement {
 		}
 	}
 	renderTrack() {
-		const $trackTitle = document.createElement('span')
-		$trackTitle.innerText = this.track.title || this.track.id
-		this.append($trackTitle)
+		const t = this.track
+		const $track = document.createElement('article')
+		render(html`
+			${t.title || t.id}<br>
+			${t.description}
+			<small>
+				${t.tags}
+				${t.mentions}
+			</small></article>
+		`, $track)
+		this.append($track)
 	}
 	renderNoTrack() {
 		const $noTrack = document.createElement('span')

--- a/src/components/r4-tracks.js
+++ b/src/components/r4-tracks.js
@@ -18,7 +18,7 @@ export default class R4Tracks extends R4List {
 			slug
 		),
 		track_id(
-			id, created_at, updated_at, title, url, description
+			id, created_at, updated_at, url, title, description, tags, mentions
 		)
 	`
 

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -9,7 +9,7 @@ template.innerHTML = `
 		<r4-channel-actions slug></r4-channel-actions>
 	</header>
 	<main>
-		<r4-tracks channel pagination="true"></r4-tracks>
+		<r4-tracks channel limit="2000" pagination="true"></r4-tracks>
 	</main>
 	<aside>
 		<r4-dialog name="update">


### PR DESCRIPTION
Adds automatic tags and mentions from the track description. It's not super useful as is, more the contrary, but it could become when we turn the tags and mentions into links.