### PR TITLE
Feature/channel update page

### DIFF
--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -198,6 +198,7 @@ export default class R4App extends LitElement {
 					<r4-route path="/new" page="new"></r4-route>
 					<r4-route path="/settings" page="settings"></r4-route>
 					<r4-route path="/:slug" page="channel"></r4-route>
+					<r4-route path="/:slug/update" page="channel-update"></r4-route>
 					<r4-route path="/:slug/tracks" page="tracks"></r4-route>
 					<r4-route path="/:slug/tracks/:track_id" page="track"></r4-route>
 				</r4-router>

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -1,0 +1,41 @@
+import { html, LitElement } from 'lit'
+import { canEditChannel, readChannel } from '@radio4000/sdk'
+
+// Base class to extend from
+export class ChannelPage extends LitElement {
+	static properties = {
+		channel: { type: Object, state: true },
+		canEdit: { type: Boolean, state: true },
+		// from the router
+		params: { type: Object, state: true },
+		store: { type: Object, state: true },
+		config: { type: Object, state: true },
+	}
+
+	get channelOrigin() {
+		return this.config.singleChannel ? this.config.href : `${this.config.href}/{{slug}}`
+	}
+
+	get tracksOrigin() {
+		if (this.config.singleChannel) {
+			return this.config.href + '/tracks/{{id}}'
+		} else {
+			return this.config.href + '/' + this.params.slug + '/tracks/{{id}}'
+		}
+	}
+
+	connectedCallback() {
+		super.connectedCallback()
+		this.setChannel()
+	}
+
+	// Set channel from the slug in the URL.
+	async setChannel() {
+		this.channel = (await readChannel(this.params.slug)).data
+		this.canEdit = await canEditChannel(this.params.slug)
+	}
+
+	render() {
+		return html``
+	}
+}

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -24,9 +24,10 @@ export default class BaseChannel extends LitElement {
 		}
 	}
 
-	connectedCallback() {
-		super.connectedCallback()
-		this.setChannel()
+	willUpdate(changedProperties) {
+		if (changedProperties.has('params')) {
+			this.setChannel()
+		}
 	}
 
 	// Set channel from the slug in the URL.

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -2,7 +2,7 @@ import { html, LitElement } from 'lit'
 import { canEditChannel, readChannel } from '@radio4000/sdk'
 
 // Base class to extend from
-export class ChannelPage extends LitElement {
+export default class BaseChannel extends LitElement {
 	static properties = {
 		channel: { type: Object, state: true },
 		canEdit: { type: Boolean, state: true },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import R4PageHome from './r4-page-home.js'
 import R4PageExplore from './r4-page-explore.js'
 import R4PageChannel from './r4-page-channel.js'
+import R4PageChannelUpdate from './r4-page-channel-update.js'
 import R4PageSign from './r4-page-sign.js'
 import R4PageAdd from './r4-page-add.js'
 import R4PageNew from './r4-page-new.js'
@@ -11,6 +12,7 @@ import R4PageSettings from './r4-page-settings'
 customElements.define('r4-page-home', R4PageHome)
 customElements.define('r4-page-explore', R4PageExplore)
 customElements.define('r4-page-channel', R4PageChannel)
+customElements.define('r4-page-channel-update', R4PageChannelUpdate)
 customElements.define('r4-page-tracks', R4PageTracks)
 customElements.define('r4-page-track', R4PageTrack)
 customElements.define('r4-page-sign', R4PageSign)
@@ -22,6 +24,7 @@ export default {
 	R4PageHome,
 	R4PageExplore,
 	R4PageChannel,
+	R4PageChannelUpdate,
 	R4PageSign,
 	R4PageAdd,
 	R4PageNew,

--- a/src/pages/r4-page-channel-update.js
+++ b/src/pages/r4-page-channel-update.js
@@ -1,0 +1,60 @@
+import { html } from 'lit'
+import { ChannelPage } from './r4-page-channel'
+import page from 'page/page.mjs'
+
+export default class R4PageChannelUpdate extends ChannelPage {
+	render() {
+		const { channel } = this
+		if (channel === null) return html`<p>404 - There is no channel with this slug.</p>`
+		if (!channel) return html`<p>Loading...</p>`
+		// if (!this.canEdit) return html`<p>You don't have permission to edit this channel.</p>`
+
+		return html`
+			<header>
+				<h1>&larr; <a href=${`/${channel.slug}`}>${channel.name}</a></h1>
+				<p>@${channel.slug}</p>
+				<p>${channel.description}</p>
+			</header>
+			<main>
+				<r4-channel-update
+					id=${channel.id}
+					slug=${channel.slug}
+					name=${channel.name}
+					description=${channel.description}
+					@submit=${this.onChannelUpdate}
+				></r4-channel-update>
+				<br />
+				<r4-avatar-update slug=${channel.slug}></r4-avatar-update>
+				<br />
+				<details>
+					<summary>Delete channel</summary>
+					<r4-channel-delete id=${channel.id} @submit=${this.onChannelDelete}></r4-channel-delete>
+				</details>
+			</main>
+		`
+	}
+
+	async onChannelDelete({ detail }) {
+		/* no error? we deleted */
+		if (!detail.data) {
+			page('/')
+		}
+	}
+
+	async onChannelUpdate({ detail }) {
+		const {
+			data: { slug: newSlug },
+		} = ({} = detail)
+
+		if (newSlug && newSlug !== this.params.slug) {
+			page(`/${newSlug}`)
+		}
+		if (!detail.error && detail.data) {
+			// we good
+		}
+	}
+
+	createRenderRoot() {
+		return this
+	}
+}

--- a/src/pages/r4-page-channel-update.js
+++ b/src/pages/r4-page-channel-update.js
@@ -1,8 +1,8 @@
 import { html } from 'lit'
 import page from 'page/page.mjs'
-import { ChannelPage } from './base-channel'
+import BaseChannel from './base-channel'
 
-export default class R4PageChannelUpdate extends ChannelPage {
+export default class R4PageChannelUpdate extends BaseChannel {
 	render() {
 		const { channel } = this
 		if (channel === null) return html`<p>404 - There is no channel with this slug.</p>`

--- a/src/pages/r4-page-channel-update.js
+++ b/src/pages/r4-page-channel-update.js
@@ -1,6 +1,6 @@
 import { html } from 'lit'
-import { ChannelPage } from './r4-page-channel'
 import page from 'page/page.mjs'
+import { ChannelPage } from './base-channel'
 
 export default class R4PageChannelUpdate extends ChannelPage {
 	render() {

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -1,10 +1,10 @@
 import { html } from 'lit'
 import page from 'page/page.mjs'
-import { ChannelPage } from './base-channel'
+import BaseChannel from './base-channel'
 
-export default class R4PageChannel extends ChannelPage {
+export default class R4PageChannel extends BaseChannel {
 	render() {
-		const {channel} = this
+		const { channel } = this
 		if (channel === null) return html`<p>404 - There is no channel with this slug.</p>`
 		if (!channel) return html`<p>Loading...</p>`
 
@@ -20,18 +20,14 @@ export default class R4PageChannel extends ChannelPage {
 					slug=${channel.slug}
 					?can-edit=${this.canEdit}
 					@input=${this.onChannelAction}
-					></r4-channel-actions>
+				></r4-channel-actions>
 			</header>
 			<main>
 				<r4-tracks channel=${channel.slug} origin=${this.tracksOrigin} limit="5"></r4-tracks>
 			</main>
 			<aside>
 				<r4-dialog name="share" @close=${this.onDialogClose}>
-					<r4-channel-sharer
-						slot="dialog"
-						origin=${this.channelOrigin}
-						slug=${channel.slug}
-						></r4-channel-sharer>
+					<r4-channel-sharer slot="dialog" origin=${this.channelOrigin} slug=${channel.slug}></r4-channel-sharer>
 				</r4-dialog>
 			</aside>
 		`
@@ -44,8 +40,8 @@ export default class R4PageChannel extends ChannelPage {
 				const playEvent = new CustomEvent('r4-play', {
 					bubbles: true,
 					detail: {
-						channel: this.params.slug
-					}
+						channel: this.params.slug,
+					},
 				})
 				this.dispatchEvent(playEvent)
 			}

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -1,45 +1,6 @@
-import { html, LitElement } from 'lit'
-import { canEditChannel, readChannel } from '@radio4000/sdk'
+import { html } from 'lit'
 import page from 'page/page.mjs'
-
-// Base class to extend from
-export class ChannelPage extends LitElement {
-	static properties = {
-		channel: { type: Object, state: true },
-		canEdit: { type: Boolean, state: true },
-		// from the router
-		params: { type: Object, state: true },
-		store: { type: Object, state: true },
-		config: { type: Object, state: true },
-	}
-
-	get channelOrigin() {
-		return this.config.singleChannel ? this.config.href : `${this.config.href}/{{slug}}`
-	}
-
-	get tracksOrigin() {
-		if (this.config.singleChannel) {
-			return this.config.href + '/tracks/{{id}}'
-		} else {
-			return this.config.href + '/' + this.params.slug + '/tracks/{{id}}'
-		}
-	}
-
-	connectedCallback() {
-		super.connectedCallback()
-		this.setChannel()
-	}
-
-	// Set channel from the slug in the URL.
-	async setChannel() {
-		this.channel = (await readChannel(this.params.slug)).data
-		this.canEdit = await canEditChannel(this.params.slug)
-	}
-
-	render() {
-		return html``
-	}
-}
+import { ChannelPage } from './base-channel'
 
 export default class R4PageChannel extends ChannelPage {
 	render() {
@@ -111,11 +72,11 @@ export default class R4PageChannel extends ChannelPage {
 		}
 	}
 
-	onDialogClose({target}) {
+	onDialogClose({ target }) {
 		const name = target.getAttribute('name')
 		if (name === 'track') {
 			if (this.config.singleChannel) {
-				page('/tracks')
+				page('/track')
 			} else {
 				page(`/${this.params.slug}/tracks`)
 			}


### PR DESCRIPTION
- Removes dialogs for updating/deleting channel on `/:slug`
- Adds new page `:/slug/update` with channel update form, delete + avatar update
- Adds a new "base channel page class" that both pages use