### PR TITLE
Feat/pagination query params

### DIFF
--- a/examples/r4-list/index.html
+++ b/examples/r4-list/index.html
@@ -20,6 +20,12 @@
 	</menu>
 	<r4-list pagination="true" model="tracks" page="1" limit="1"></r4-list>
 
+	<script>
+		document.querySelector('r4-list').addEventListener('r4-list', (event) => {
+			console.log('r4-list event on first r4-list DOM element', event.detail)
+		})
+	</script>
+
 	<menu>
 		<li>
 			The list can have pagination, here for <code>model="tracks"</code>

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -186,7 +186,7 @@ export default class R4App extends LitElement {
 					.config=${this.config}
 					>
 					<r4-route path="/" page="home"></r4-route>
-					<r4-route path="/explore" page="explore"></r4-route>
+					<r4-route path="/explore" page="explore" query-params="page,limit"></r4-route>
 					<r4-route path="/sign" page="sign"></r4-route>
 					<r4-route path="/sign/:method" page="sign"></r4-route>
 					<r4-route path="/add" page="add" query-params="slug,url"></r4-route>

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -172,7 +172,7 @@ export default class R4App extends LitElement {
 					<r4-route path="/sign/:method" page="sign"></r4-route>
 					<r4-route path="/" page="channel"></r4-route>
 					<r4-route path="/player" page="channel-player"></r4-route>
-					<r4-route path="/tracks" page="channel-tracks"></r4-route>
+					<r4-route path="/tracks" page="channel-tracks" query-params="page,limit"></r4-route>
 					<r4-route path="/tracks/:track_id" page="channel-track" query-params="slug,url"></r4-route>
 					<r4-route path="/add" page="add" query-params="url"></r4-route>
 					<r4-route path="/settings" page="settings"></r4-route>
@@ -196,7 +196,7 @@ export default class R4App extends LitElement {
 					<r4-route path="/:slug" page="channel"></r4-route>
 					<r4-route path="/:slug/update" page="channel-update"></r4-route>
 					<r4-route path="/:slug/player" page="channel-player"></r4-route>
-					<r4-route path="/:slug/tracks" page="channel-tracks"></r4-route>
+					<r4-route path="/:slug/tracks" page="channel-tracks" query-params="page,limit"></r4-route>
 					<r4-route path="/:slug/tracks/:track_id" page="channel-track"></r4-route>
 				</r4-router>
 			`

--- a/src/components/r4-list.js
+++ b/src/components/r4-list.js
@@ -78,10 +78,12 @@ export default class R4List extends HTMLElement {
 	}
 
 	/* if the attribute changed, re-render */
-	async attributeChangedCallback(attrName) {
+	async attributeChangedCallback(attrName, oldVal, newVal) {
 		/* the page changes, update the list */
 		if (['page', 'limit'].indexOf(attrName) > -1) {
-			await this.updateList()
+			if (oldVal !== newVal) {
+				await this.updateList()
+			}
 		}
 		/* the list of items changes, update the DOM */
 		if (['list'].indexOf(attrName) > -1) {
@@ -118,10 +120,20 @@ export default class R4List extends HTMLElement {
 		} else {
 			/* this.list = [] */
 		}
+
+		const listEvent = new CustomEvent('r4-list', {
+			bubbles: true,
+			detail: {
+				page: this.page,
+				limit: this.limit,
+				list: this.list,
+			}
+		})
+		this.dispatchEvent(listEvent)
 	}
 
 	/* browse the list (of data models) like it is paginated;
-	 components-attributes -> supbase-query */
+		 components-attributes -> supbase-query */
 	async browsePage({page, limit}) {
 		const { from, to, limitResults } = this.getBrowseParams({ page, limit })
 		return sdk.supabase
@@ -240,7 +252,6 @@ export default class R4List extends HTMLElement {
 			if (modelName) {
 				$li.innerText = `No more ${modelName}s`
 			} else if (modelElementName) {
-				console.log(this.itemTemplate)
 				$li.innerText = `No more ${modelElementName}`
 			}
 		} else {

--- a/src/components/r4-tracks.js
+++ b/src/components/r4-tracks.js
@@ -39,7 +39,7 @@ export default class R4Tracks extends R4List {
 	}
 
 	async attributeChangedCallback(attrName) {
-		super.attributeChangedCallback(attrName)
+		super.attributeChangedCallback(...arguments)
 		/* the slug changes, update the list */
 		if (['channel'].indexOf(attrName) > -1) {
 			await this.updateList()

--- a/src/pages/r4-page-channel-tracks.js
+++ b/src/pages/r4-page-channel-tracks.js
@@ -6,6 +6,7 @@ export default class R4PageChannelTracks extends LitElement {
 	static properties = {
 		store: { type: Object, state: true },
 		params: { type: Object, state: true },
+		query: { type: Object, state: true },
 		config: { type: Object, state: true },
 
 		channel: { type: Object, reflect: true, state: true },
@@ -67,8 +68,10 @@ export default class R4PageChannelTracks extends LitElement {
 				<r4-tracks
 					channel=${channel.slug}
 					origin=${this.tracksOrigin}
-					limit="10"
+					limit=${this.query.limit || 10}
+					page=${this.query.page || 1}
 					pagination="true"
+					@r4-list=${this.onNavigateList}
 					></r4-tracks>
 			</main>
 		`
@@ -83,5 +86,22 @@ export default class R4PageChannelTracks extends LitElement {
 	/* no shadow dom */
 	createRenderRoot() {
 		return this
+	}
+
+	onNavigateList({detail}) {
+		/* `page` here, is usually globaly the "router", beware */
+		const {page: currentPage, limit, list} = detail
+		const newPageURL = new URL(window.location)
+
+		limit && newPageURL.searchParams.set('limit', limit)
+		currentPage && newPageURL.searchParams.set('page', currentPage)
+
+		if (window.location.href !== newPageURL.href) {
+			history.replaceState({}, window.title, newPageURL.href)
+			/*
+				 do not use page, as it would reload the initial html
+				 page(newPageURL.href)
+			 */
+		}
 	}
 }

--- a/src/pages/r4-page-explore.js
+++ b/src/pages/r4-page-explore.js
@@ -4,6 +4,7 @@ export default class R4PageExplore extends LitElement {
 	static properties = {
 		/* props */
 		config: { type: Object },
+		query: { type: Object, state: true },
 	}
 	get channelOrigin() {
 		return `${this.config.href}/{{slug}}`
@@ -17,14 +18,29 @@ export default class R4PageExplore extends LitElement {
 			</header>
 			<section>
 				<r4-channels
+					@r4-list=${this.onNavigateList}
 					origin=${this.channelOrigin}
 					pagination="true"
-					limit="15"
+					limit=${this.query.limit || 15}
+					page=${this.query.page || 1}
 				></r4-channels>
 			</section>
 		`
 	}
 	createRenderRoot() {
 		return this
+	}
+
+	onNavigateList({detail}) {
+		/* `page` here, is usually globaly the "router", beware */
+		const {page: currentPage, limit, list} = detail
+		const newPageURL = new URL(window.location)
+
+		limit && newPageURL.searchParams.set('limit', limit)
+		currentPage && newPageURL.searchParams.set('page', currentPage)
+
+		if (window.location.href !== newPageURL.href) {
+			history.replaceState({}, window.title, newPageURL.href)
+		}
 	}
 }


### PR DESCRIPTION
- add r4-list `@r4-list` event, with `{page, limit, list}` pagination data
- bind `/:slug/:track/?limit&page` attributes, also on `/explore?limit&page`

There are still bugs i can't figure:
- back button in history is kroken
- should navigating the pages make browser history item (so previous/next page navigate the list)
- etc.