### PR TITLE
Followers

### DIFF
--- a/examples/r4-channel-followers/index.html
+++ b/examples/r4-channel-followers/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
+	<link rel="icon" href="data:;base64,iVBORw0KGgo=">
+
+	<title>r4-channel-followers</title>
+	<meta name="description" content="r4-channel-followers">
+	<link rel="stylesheet" href="/styles/index.css" />
+	<script type="module" src="/src/index.js"></script>
+</head>
+
+<body>
+	<menu>
+		<li>
+			By default, will browse all <r4-title></r4-title> tracks.
+		</li>
+		<li>
+			Enter a <a href="?channel-id=">channel id</a> as a url parameter, to fetch this channel's followers.
+		</li>
+	</menu>
+	<r4-channel-followers pagination="true"></r4-channel-followers>
+</body>
+
+<script>
+	/* use the query parameter, `slug`: `?slug={channel_slug}` */
+	const $followers = document.querySelector('r4-channel-followers')
+	const params = new URLSearchParams(window.location.search)
+	const id = params.get('channel-id')
+	id && $followers.setAttribute('channel-id', id)
+</script>
+
+</html>

--- a/examples/r4-channel-followings/index.html
+++ b/examples/r4-channel-followings/index.html
@@ -6,8 +6,8 @@
 	<meta name="viewport" content="width=device-width">
 	<link rel="icon" href="data:;base64,iVBORw0KGgo=">
 
-	<title>r4-channel-followers</title>
-	<meta name="description" content="r4-channel-followers">
+	<title>r4-channel-followings</title>
+	<meta name="description" content="r4-channel-followings">
 	<link rel="stylesheet" href="/styles/index.css" />
 	<script type="module" src="/src/index.js"></script>
 </head>
@@ -15,18 +15,18 @@
 <body>
 	<menu>
 		<li>
-			By default, will browse all channels, followers of a channel.
+			By default, will browse all channels a channel is following.
 		</li>
 		<li>
-			Enter a <a href="?channel-id=">channel id</a> as a url parameter, to fetch this channel's followers.
+			Enter a <a href="?channel-id=">channel id</a> as a url parameter, to fetch this channel's followings.
 		</li>
 	</menu>
-	<r4-channel-followers pagination="true"></r4-channel-followers>
+	<r4-channel-followings pagination="true"></r4-channel-followings>
 </body>
 
 <script>
 	/* use the query parameter, `slug`: `?slug={channel_slug}` */
-	const $followers = document.querySelector('r4-channel-followers')
+	const $followers = document.querySelector('r4-channel-followings')
 	const params = new URLSearchParams(window.location.search)
 	const id = params.get('channel-id')
 	id && $followers.setAttribute('channel-id', id)

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,6 +17,7 @@ import R4ChannelDelete from './r4-channel-delete.js'
 import R4ChannelSharer from './r4-channel-sharer.js'
 import R4ChannelUpdate from './r4-channel-update.js'
 import R4ChannelFollowers from './r4-channel-followers.js'
+import R4ChannelFollowings from './r4-channel-followings.js'
 import R4Channels from './r4-channels.js'
 import R4Dialog from './r4-dialog.js'
 import R4Favicon from './r4-favicon.js'
@@ -57,6 +58,7 @@ customElements.define('r4-channel-delete', R4ChannelDelete)
 customElements.define('r4-channel-sharer', R4ChannelSharer)
 customElements.define('r4-channel-update', R4ChannelUpdate)
 customElements.define('r4-channel-followers', R4ChannelFollowers)
+customElements.define('r4-channel-followings', R4ChannelFollowings)
 customElements.define('r4-channels', R4Channels)
 customElements.define('r4-dialog', R4Dialog)
 customElements.define('r4-favicon', R4Favicon)
@@ -97,6 +99,7 @@ export default {
 	R4ChannelSharer,
 	R4ChannelUpdate,
 	R4ChannelFollowers,
+	R4ChannelFollowings,
 	R4Channels,
 	R4Dialog,
 	R4Favicon,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -16,6 +16,7 @@ import R4ChannelCreate from './r4-channel-create.js'
 import R4ChannelDelete from './r4-channel-delete.js'
 import R4ChannelSharer from './r4-channel-sharer.js'
 import R4ChannelUpdate from './r4-channel-update.js'
+import R4ChannelFollowers from './r4-channel-followers.js'
 import R4Channels from './r4-channels.js'
 import R4Dialog from './r4-dialog.js'
 import R4Favicon from './r4-favicon.js'
@@ -55,6 +56,7 @@ customElements.define('r4-channel-create', R4ChannelCreate)
 customElements.define('r4-channel-delete', R4ChannelDelete)
 customElements.define('r4-channel-sharer', R4ChannelSharer)
 customElements.define('r4-channel-update', R4ChannelUpdate)
+customElements.define('r4-channel-followers', R4ChannelFollowers)
 customElements.define('r4-channels', R4Channels)
 customElements.define('r4-dialog', R4Dialog)
 customElements.define('r4-favicon', R4Favicon)
@@ -94,6 +96,7 @@ export default {
 	R4ChannelDelete,
 	R4ChannelSharer,
 	R4ChannelUpdate,
+	R4ChannelFollowers,
 	R4Channels,
 	R4Dialog,
 	R4Favicon,

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -114,6 +114,7 @@ export default class R4App extends LitElement {
 			if (!this.config.selectedSlug) {
 				this.selectedSlug = this.store.userChannels[0].slug
 			}
+
 			if (this.selectedChannel) {
 				const {data: followers} = await sdk.channels.readFollowers(this.selectedChannel.id)
 				const {data: followings} = await sdk.channels.readFollowings(this.selectedChannel.id)
@@ -128,6 +129,8 @@ export default class R4App extends LitElement {
 
 		} else {
 			this.userChannels = undefined
+			this.followers = undefined
+			this.followings = undefined
 		}
 
 		this.didLoad = true

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -4,9 +4,6 @@ import {sdk} from '@radio4000/sdk'
 import page from 'page/page.mjs'
 import '../pages/'
 
-// https://github.com/visionmedia/page.js/issues/537
-/* page.configure({ window: window }) */
-
 export default class R4App extends LitElement {
 	playerRef = createRef()
 
@@ -140,8 +137,6 @@ export default class R4App extends LitElement {
 	// When this is run, `user` and `userChannels` can be undefined.
 	async setupDatabaseListeners() {
 		// always cleanup existing listeners
-		console.log('setup listeners')
-		console.log('setup cleaning listeners')
 		await this.removeDatabaseListeners()
 
 		if (this.userChannels) {
@@ -155,7 +150,6 @@ export default class R4App extends LitElement {
 			}, (payload) => {
 				this.refreshUserData()
 			}).subscribe()
-			console.info('listen@user-channels-changes')
 		}
 
 		const userChannelEvents = sdk.supabase.channel('user-channels-events')
@@ -171,10 +165,8 @@ export default class R4App extends LitElement {
 				await this.refreshUserData()
 			}
 		}).subscribe()
-		console.info('listen@user-channels-events')
 
 		if (this.selectedChannel?.id) {
-			console.table('id', this.selectedChannel?.id)
 			const userFavoriteEvents = sdk.supabase.channel('user-channel-favorites')
 			userFavoriteEvents.on('postgres_changes', {
 				event: '*',
@@ -187,12 +179,10 @@ export default class R4App extends LitElement {
 					await this.refreshUserData()
 				}
 			}).subscribe()
-			console.info('listen@user-channel-favorites')
 		}
 	}
 
 	async removeDatabaseListeners() {
-		console.log('removing database listeners')
 		return sdk.supabase.removeAllChannels()
 	}
 

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -229,6 +229,8 @@ export default class R4App extends LitElement {
 					<r4-route path="/player" page="channel-player"></r4-route>
 					<r4-route path="/tracks" page="channel-tracks" query-params="page,limit"></r4-route>
 					<r4-route path="/tracks/:track_id" page="channel-track" query-params="slug,url"></r4-route>
+					<r4-route path="//followers" page="channel-followers" query-params="page,limit"></r4-route>
+					<r4-route path="/followings" page="channel-followings" query-params="page,limit"></r4-route>
 					<r4-route path="/add" page="add" query-params="url"></r4-route>
 					<r4-route path="/settings" page="settings"></r4-route>
 				</r4-router>
@@ -253,6 +255,8 @@ export default class R4App extends LitElement {
 					<r4-route path="/:slug/player" page="channel-player"></r4-route>
 					<r4-route path="/:slug/tracks" page="channel-tracks" query-params="page,limit"></r4-route>
 					<r4-route path="/:slug/tracks/:track_id" page="channel-track"></r4-route>
+					<r4-route path="/:slug/followers" page="channel-followers" query-params="page,limit"></r4-route>
+					<r4-route path="/:slug/followings" page="channel-followings" query-params="page,limit"></r4-route>
 				</r4-router>
 			`
 		}

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -28,6 +28,8 @@ export default class R4App extends LitElement {
 		/* state */
 		user: {type: Object, state: true},
 		userChannels: {type: Array || null, state: true},
+		followers: {type: Array || null, state: true},
+		followings: {type: Array || null, state: true},
 		didLoad: {type: Boolean, state: true},
 		isPlaying: {type: Boolean, attribute: 'is-playing', reflects: true},
 

--- a/src/components/r4-channel-actions.js
+++ b/src/components/r4-channel-actions.js
@@ -6,6 +6,8 @@ template.innerHTML = `
 		<option value="">...</option>
 		<option value="play">Play</option>
 		<option value="tracks">Tracks</option>
+		<option value="followings">Followings</option>
+		<option value="followers">Followers</option>
 		<option value="share">Share</option>
 	</r4-actions>
 `

--- a/src/components/r4-channel-follow.js
+++ b/src/components/r4-channel-follow.js
@@ -1,0 +1,3 @@
+import {sdk} from '@radio4000/sdk'
+
+export default class R4ChannelFollow extends HTMLElement {}

--- a/src/components/r4-channel-followers.js
+++ b/src/components/r4-channel-followers.js
@@ -1,0 +1,77 @@
+import R4List from './r4-list.js'
+import {sdk} from '@radio4000/sdk'
+
+const itemTemplate = document.createElement('template')
+/* This will set the whole item (channel) json,
+	 as attribute "track", on the <r4-channel/> element */
+itemTemplate.setAttribute('element', 'r4-channel')
+itemTemplate.setAttribute('attribute', 'channel')
+itemTemplate.innerHTML = `<r4-channel><r4-channel/>`
+
+
+export default class R4ChannelFollowers extends R4List {
+	static get observedAttributes() {
+		return ['channel-id', ...R4List.observedAttributes]
+	}
+
+	itemTemplate = itemTemplate
+
+	model = 'followers'
+
+	select = `
+		follower_id (
+			id, name, slug, description, created_at, image, url
+		)
+	`
+
+	/* specific to track */
+	eq = 'channel_id'
+
+	get orderConfig() {
+		return { ascending: false }
+	}
+
+	/* the channel slug */
+	get channelId() {
+		return this.getAttribute('channel-id')
+	}
+
+	async attributeChangedCallback(attrName) {
+		super.attributeChangedCallback(...arguments)
+		/* the slug changes, update the list */
+		if (['channel-id'].indexOf(attrName) > -1) {
+			await this.updateList()
+		}
+	}
+	/* browse all tracks,or just tracks for a specific channel */
+	async browsePage({ page, limit }) {
+		/* if there is a channel attribute, even empty */
+		if (this.attributes['channel-id']) {
+			/* if it has a value */
+			if (this.channelId) {
+				const browseParams = this.getBrowseParams({ page, limit })
+				const data = await this.browseChannelFollowersPage(browseParams)
+				return data
+			}
+		}
+	}
+
+	/* browse all tracks for a specific channel slug */
+	async browseChannelFollowersPage({ from, to, limitResults }) {
+		const res = await sdk.supabase
+			.from(this.model)
+			.select(this.select)
+			.limit(limitResults)
+			.order(this.orderKey, this.orderConfig)
+			.eq(this.eq, this.channelId)
+			.range(from, to)
+
+		/* serialize junction table response */
+		if (res && res.data) {
+			res.data = res.data.map((item) => {
+				return item.follower_id
+			})
+			return res
+		}
+	}
+}

--- a/src/components/r4-channel-followings.js
+++ b/src/components/r4-channel-followings.js
@@ -1,0 +1,77 @@
+import R4List from './r4-list.js'
+import {sdk} from '@radio4000/sdk'
+
+const itemTemplate = document.createElement('template')
+/* This will set the whole item (channel) json,
+	 as attribute "track", on the <r4-channel/> element */
+itemTemplate.setAttribute('element', 'r4-channel')
+itemTemplate.setAttribute('attribute', 'channel')
+itemTemplate.innerHTML = `<r4-channel><r4-channel/>`
+
+
+export default class R4ChannelFollowings extends R4List {
+	static get observedAttributes() {
+		return ['channel-id', ...R4List.observedAttributes]
+	}
+
+	itemTemplate = itemTemplate
+
+	model = 'followers'
+
+	select = `
+		channel_id (
+			id, name, slug, description, created_at, image, url
+		)
+	`
+
+	/* specific to track */
+	eq = 'follower_id'
+
+	get orderConfig() {
+		return { ascending: false }
+	}
+
+	/* the channel slug */
+	get channelId() {
+		return this.getAttribute('channel-id')
+	}
+
+	async attributeChangedCallback(attrName) {
+		super.attributeChangedCallback(...arguments)
+		/* the slug changes, update the list */
+		if (['channel-id'].indexOf(attrName) > -1) {
+			await this.updateList()
+		}
+	}
+	/* browse all tracks,or just tracks for a specific channel */
+	async browsePage({ page, limit }) {
+		/* if there is a channel attribute, even empty */
+		if (this.attributes['channel-id']) {
+			/* if it has a value */
+			if (this.channelId) {
+				const browseParams = this.getBrowseParams({ page, limit })
+				const data = await this.browseChannelFollowersPage(browseParams)
+				return data
+			}
+		}
+	}
+
+	/* browse all tracks for a specific channel slug */
+	async browseChannelFollowersPage({ from, to, limitResults }) {
+		const res = await sdk.supabase
+			.from(this.model)
+			.select(this.select)
+			.limit(limitResults)
+			.order(this.orderKey, this.orderConfig)
+			.eq(this.eq, this.channelId)
+			.range(from, to)
+
+		/* serialize junction table response */
+		if (res && res.data) {
+			res.data = res.data.map((item) => {
+				return item.channel_id
+			})
+			return res
+		}
+	}
+}

--- a/src/components/r4-router.js
+++ b/src/components/r4-router.js
@@ -2,6 +2,9 @@ import { LitElement, render } from 'lit'
 import {html, literal, unsafeStatic} from 'lit/static-html.js'
 import page from 'page/page.mjs'
 
+// https://github.com/visionmedia/page.js/issues/537
+page.configure({ window: window })
+
 export default class R4Router extends LitElement {
 	static properties = {
 		/* props attribute */
@@ -13,9 +16,9 @@ export default class R4Router extends LitElement {
 	get pathname() {
 		const href = this.config.href || window.location.href
 		let name = new URL(href).pathname
-		if (name.endsWith('/')) {
-			name = name.slice(0, name.length - 1)
-		}
+		/* if (name.endsWith('/')) {
+			 name = name.slice(0, name.length - 1)
+			 } */
 		return name
 	}
 
@@ -29,7 +32,8 @@ export default class R4Router extends LitElement {
 	}
 
 	handleFirstUrl() {
-		page(window.location)
+		const initialURL = new URL(window.location.href)
+		page(initialURL.pathname + initialURL.search)
 	}
 
 	setupRouter() {
@@ -47,7 +51,7 @@ export default class R4Router extends LitElement {
 	}
 
 	setupRoute($route) {
-		page($route.getAttribute('path'), this.parseQuery, (ctx, next) => this.renderRoute($route, ctx))
+		page($route.getAttribute('path'), this.parseQuery.bind(this), (ctx, next) => this.renderRoute($route, ctx))
 		page.exit($route.getAttribute('path'), (ctx, next) => this.unrenderRoute($route, ctx, next))
 	}
 
@@ -84,6 +88,7 @@ export default class R4Router extends LitElement {
 	}
 
 	render() {
+		if (!this.pageName) return
 		const tag = literal`r4-page-${unsafeStatic(this.pageName)}`
 		const $pageDom = html`
 			<${tag} .store=${this.store} .config=${this.config} .query=${this.query} .params=${this.params}></${tag}>

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -19,6 +19,11 @@ export default class BaseChannel extends LitElement {
 		return this.config.singleChannel ? this.config.href : `${this.config.href}/${this.channel.slug}`
 	}
 
+	buildChannelHref(channel) {
+		return `${this.config.href}/${channel.slug}`
+	}
+
+
 	get tracksOrigin() {
 		if (this.config.singleChannel) {
 			return this.config.href + '/tracks/{{id}}'
@@ -39,7 +44,6 @@ export default class BaseChannel extends LitElement {
 		if (changedProperties.has('params')) {
 			this.setChannel()
 		}
-		console.log('base channel willUpdate', this.alreadyFollowing, this.followsYou, this.store)
 	}
 
 	// Set channel from the slug in the URL.

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -6,8 +6,8 @@ export default class BaseChannel extends LitElement {
 	static properties = {
 		channel: { type: Object, state: true },
 		canEdit: { type: Boolean, state: true, reflect: true },
-		isFollowing: { type: Boolean, state: true, reflect: true },
-		isFollower: { type: Boolean, state: true, reflect: true },
+		alreadyFollowing: { type: Boolean, state: true, reflect: true },
+		followsYou: { type: Boolean, state: true, reflect: true },
 
 		// from the router
 		params: { type: Object, state: true },

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -27,23 +27,19 @@ export default class BaseChannel extends LitElement {
 		}
 	}
 
-	get isFollower() {
-		return (
-			this.store?.followers?.find(({slug}) => slug === this.params.slug)
-		)
+	get alreadyFollowing() {
+		return this.store.followings?.map(c => c.slug).includes(this.channel?.slug)
 	}
 
-	get isFollowed() {
-		return (
-			this.store?.following?.find(({slug}) => slug === this.params.slug)
-		)
+	get followsYou() {
+		return this.store.followers?.map(c => c.slug).includes(this.config.selectedSlug)
 	}
 
 	willUpdate(changedProperties) {
 		if (changedProperties.has('params')) {
 			this.setChannel()
 		}
-		console.log('base channel willUpdate', this.store, this.isAFollower, this.isBeingFollowed)
+		console.log('base channel willUpdate', this.alreadyFollowing, this.followsYou, this.store)
 	}
 
 	// Set channel from the slug in the URL.

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -33,10 +33,12 @@ export default class BaseChannel extends LitElement {
 	}
 
 	get alreadyFollowing() {
+		if (!this.store.user) return
 		return this.store.followings?.map(c => c.slug).includes(this.channel?.slug)
 	}
 
 	get followsYou() {
+		if (!this.store.user) return
 		return this.store.followers?.map(c => c.slug).includes(this.config.selectedSlug)
 	}
 

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -5,7 +5,10 @@ import {sdk} from '@radio4000/sdk'
 export default class BaseChannel extends LitElement {
 	static properties = {
 		channel: { type: Object, state: true },
-		canEdit: { type: Boolean, state: true },
+		canEdit: { type: Boolean, state: true, reflect: true },
+		isFollowing: { type: Boolean, state: true, reflect: true },
+		isFollower: { type: Boolean, state: true, reflect: true },
+
 		// from the router
 		params: { type: Object, state: true },
 		store: { type: Object, state: true },
@@ -24,10 +27,23 @@ export default class BaseChannel extends LitElement {
 		}
 	}
 
+	get isFollower() {
+		return (
+			this.store?.followers?.find(({slug}) => slug === this.params.slug)
+		)
+	}
+
+	get isFollowed() {
+		return (
+			this.store?.following?.find(({slug}) => slug === this.params.slug)
+		)
+	}
+
 	willUpdate(changedProperties) {
 		if (changedProperties.has('params')) {
 			this.setChannel()
 		}
+		console.log('base channel willUpdate', this.store, this.isAFollower, this.isBeingFollowed)
 	}
 
 	// Set channel from the slug in the URL.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,8 @@ import R4PageAdd from './r4-page-add.js'
 import R4PageChannel from './r4-page-channel.js'
 import R4PageChannelUpdate from './r4-page-channel-update.js'
 import R4PageChannelPlayer from './r4-page-channel-player.js'
+import R4PageChannelFollowings from './r4-page-channel-followings.js'
+import R4PageChannelFollowers from './r4-page-channel-followers.js'
 import R4PageExplore from './r4-page-explore.js'
 import R4PageHome from './r4-page-home.js'
 import R4PageMap from './r4-page-map.js'
@@ -23,6 +25,8 @@ customElements.define('r4-page-channel-update', R4PageChannelUpdate)
 customElements.define('r4-page-channel-player', R4PageChannelPlayer)
 customElements.define('r4-page-channel-track', R4PageChannelTrack)
 customElements.define('r4-page-channel-tracks', R4PageChannelTracks)
+customElements.define('r4-page-channel-followings', R4PageChannelFollowings)
+customElements.define('r4-page-channel-followers', R4PageChannelFollowers)
 
 export default {
 	R4PageAdd,
@@ -37,4 +41,6 @@ export default {
 	R4PageSign,
 	R4PageChannelTrack,
 	R4PageChannelTracks,
+	R4PageChannelFollowings,
+	R4PageChannelFollowers,
 }

--- a/src/pages/r4-page-channel-followers.js
+++ b/src/pages/r4-page-channel-followers.js
@@ -2,6 +2,7 @@ import { html, LitElement } from 'lit'
 import { until } from 'lit/directives/until.js'
 import {sdk} from '@radio4000/sdk'
 import BaseChannel from './base-channel'
+import page from 'page/page.mjs'
 
 export default class R4PageChannelFollowers extends BaseChannel {
 	render() {
@@ -57,11 +58,7 @@ export default class R4PageChannelFollowers extends BaseChannel {
 		currentPage && newPageURL.searchParams.set('page', currentPage)
 
 		if (window.location.href !== newPageURL.href) {
-			history.replaceState({}, window.title, newPageURL.href)
-			/*
-				 do not use page, as it would reload the initial html
-				 page(newPageURL.href)
-			 */
+			page(newPageURL.pathname + newPageURL.search)
 		}
 	}
 }

--- a/src/pages/r4-page-channel-followers.js
+++ b/src/pages/r4-page-channel-followers.js
@@ -1,0 +1,67 @@
+import { html, LitElement } from 'lit'
+import { until } from 'lit/directives/until.js'
+import {sdk} from '@radio4000/sdk'
+import BaseChannel from './base-channel'
+
+export default class R4PageChannelFollowers extends BaseChannel {
+	render() {
+		return html`${
+			until(
+				Promise.resolve(this.channel).then((channel) => {
+					return channel ? this.renderPage(channel) : this.renderNoPage()
+				}).catch(() => this.renderNoPage()),
+				this.renderLoading()
+			)
+		}`
+	}
+
+	renderPage(channel) {
+		const channelOrigin = this.buildChannelHref(channel)
+		return html`
+			<header>
+				<code>@</code>
+				<a href=${channelOrigin}>${channel.slug}</a>
+				<code>/</code>
+				<a href=${channelOrigin + '/followers'}>followers</a>
+			</header>
+			<main>
+				<r4-channel-followers
+					channel-id=${channel.id}
+					origin=${channelOrigin}
+					limit=${this.query.limit || 10}
+					page=${this.query.page || 1}
+					pagination="true"
+					@r4-list=${this.onNavigateList}
+					></r4-channel-followers>
+			</main>
+		`
+	}
+	renderNoPage() {
+		return html`404 - No channel with this slug`
+	}
+	renderLoading() {
+		return html`<span>Loading channel followers...</span>`
+	}
+
+	/* no shadow dom */
+	createRenderRoot() {
+		return this
+	}
+
+	onNavigateList({detail}) {
+		/* `page` here, is usually globaly the "router", beware */
+		const {page: currentPage, limit, list} = detail
+		const newPageURL = new URL(window.location)
+
+		limit && newPageURL.searchParams.set('limit', limit)
+		currentPage && newPageURL.searchParams.set('page', currentPage)
+
+		if (window.location.href !== newPageURL.href) {
+			history.replaceState({}, window.title, newPageURL.href)
+			/*
+				 do not use page, as it would reload the initial html
+				 page(newPageURL.href)
+			 */
+		}
+	}
+}

--- a/src/pages/r4-page-channel-followings.js
+++ b/src/pages/r4-page-channel-followings.js
@@ -2,6 +2,7 @@ import { html, LitElement } from 'lit'
 import { until } from 'lit/directives/until.js'
 import {sdk} from '@radio4000/sdk'
 import BaseChannel from './base-channel'
+import page from 'page/page.mjs'
 
 export default class R4PageChannelFollowings extends BaseChannel {
 	render() {
@@ -57,11 +58,7 @@ export default class R4PageChannelFollowings extends BaseChannel {
 		currentPage && newPageURL.searchParams.set('page', currentPage)
 
 		if (window.location.href !== newPageURL.href) {
-			history.replaceState({}, window.title, newPageURL.href)
-			/*
-				 do not use page, as it would reload the initial html
-				 page(newPageURL.href)
-			 */
+			page(newPageURL.pathname + newPageURL.search)
 		}
 	}
 }

--- a/src/pages/r4-page-channel-followings.js
+++ b/src/pages/r4-page-channel-followings.js
@@ -1,0 +1,67 @@
+import { html, LitElement } from 'lit'
+import { until } from 'lit/directives/until.js'
+import {sdk} from '@radio4000/sdk'
+import BaseChannel from './base-channel'
+
+export default class R4PageChannelFollowings extends BaseChannel {
+	render() {
+		return html`${
+			until(
+				Promise.resolve(this.channel).then((channel) => {
+					return channel ? this.renderPage(channel) : this.renderNoPage()
+				}).catch(() => this.renderNoPage()),
+				this.renderLoading()
+			)
+		}`
+	}
+
+	renderPage(channel) {
+		const channelOrigin = this.buildChannelHref(channel)
+		return html`
+			<header>
+				<code>@</code>
+				<a href=${channelOrigin}>${channel.slug}</a>
+				<code>/</code>
+				<a href=${channelOrigin + '/followings'}>followings</a>
+			</header>
+			<main>
+				<r4-channel-followings
+					channel-id=${channel.id}
+					origin=${channelOrigin}
+					limit=${this.query.limit || 10}
+					page=${this.query.page || 1}
+					pagination="true"
+					@r4-list=${this.onNavigateList}
+					></r4-channel-followings>
+			</main>
+		`
+	}
+	renderNoPage() {
+		return html`404 - No channel with this slug`
+	}
+	renderLoading() {
+		return html`<span>Loading channel followings...</span>`
+	}
+
+	/* no shadow dom */
+	createRenderRoot() {
+		return this
+	}
+
+	onNavigateList({detail}) {
+		/* `page` here, is usually globaly the "router", beware */
+		const {page: currentPage, limit, list} = detail
+		const newPageURL = new URL(window.location)
+
+		limit && newPageURL.searchParams.set('limit', limit)
+		currentPage && newPageURL.searchParams.set('page', currentPage)
+
+		if (window.location.href !== newPageURL.href) {
+			history.replaceState({}, window.title, newPageURL.href)
+			/*
+				 do not use page, as it would reload the initial html
+				 page(newPageURL.href)
+			 */
+		}
+	}
+}

--- a/src/pages/r4-page-channel-tracks.js
+++ b/src/pages/r4-page-channel-tracks.js
@@ -1,6 +1,7 @@
 import { html, LitElement } from 'lit'
 import { until } from 'lit/directives/until.js'
 import {sdk} from '@radio4000/sdk'
+import page from 'page/page.mjs'
 
 export default class R4PageChannelTracks extends LitElement {
 	static properties = {
@@ -97,11 +98,7 @@ export default class R4PageChannelTracks extends LitElement {
 		currentPage && newPageURL.searchParams.set('page', currentPage)
 
 		if (window.location.href !== newPageURL.href) {
-			history.replaceState({}, window.title, newPageURL.href)
-			/*
-				 do not use page, as it would reload the initial html
-				 page(newPageURL.href)
-			 */
+			page(newPageURL.pathname + newPageURL.search)
 		}
 	}
 }

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -1,6 +1,7 @@
 import { html } from 'lit'
 import page from 'page/page.mjs'
 import BaseChannel from './base-channel'
+import {sdk} from '@radio4000/sdk'
 
 export default class R4PageChannel extends BaseChannel {
 	get coordinates() {
@@ -11,12 +12,34 @@ export default class R4PageChannel extends BaseChannel {
 			}
 		}
 	}
+
+	get alreadyFollowing() {
+		const followings = this.store.followings.map(c => c.channel_id.slug)
+		return followings.includes(this.channel.slug)
+	}
+
+	follow() {
+		const userChannel = this.store.userChannels.find(c => c.slug === this.config.selectedSlug)
+		return sdk.channels.followChannel(userChannel.id, this.channel.id)
+	}
+
+	unfollow() {
+		const userChannel = this.store.userChannels.find(c => c.slug === this.config.selectedSlug)
+		return sdk.channels.unfollowChannel(userChannel.id, this.channel.id)
+	}
+
 	render() {
 		const { channel } = this
 		if (channel === null) return html`<p>404 - There is no channel with this slug.</p>`
 		if (!channel) return html`<p>Loading...</p>`
 
 		return html`
+		<menu>
+			${this.alreadyFollowing ?
+				html`<button @click=${this.unfollow}>Unfollow</button>` :
+				html`<button @click=${this.follow}>Follow</button>`
+			}
+
 			<r4-page-actions>
 				<r4-channel-actions
 					slug=${channel.slug}

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -30,25 +30,24 @@ export default class R4PageChannel extends BaseChannel {
 
 		return html`
 		<menu>
-
 			<r4-page-actions>
-				<r4-channel-actions
-					slug=${channel.slug}
-					?can-edit=${this.canEdit}
-					@input=${this.onChannelAction}
-				></r4-channel-actions>
+				<r4-button-play .channel=${channel}></r4-button-play>
 
-				${this.followsYou ? html`<p>follows you</p>` : html`<p>doesn't follow you</p>`}
 				${this.alreadyFollowing ?
 					html`<button @click=${this.unfollow}>Unfollow</button>` :
 					html`<button @click=${this.follow}>Follow</button>`
 				}
+				${this.followsYou ? html`<p>follows you</p>` : html`<p>doesn't follow you</p>`}
 
 				<r4-channel-coordinates>
 					${ this.coordinates? this.renderMap() : null}
 				</r4-channel-coordinates>
 
-				<r4-button-play .channel=${channel}></r4-button-play>
+				<r4-channel-actions
+					slug=${channel.slug}
+					?can-edit=${this.canEdit}
+					@input=${this.onChannelAction}
+				></r4-channel-actions>
 			</r4-page-actions>
 
 			<r4-page-header>

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -22,7 +22,10 @@ export default class R4PageChannel extends BaseChannel {
 					slug=${channel.slug}
 					?can-edit=${this.canEdit}
 					@input=${this.onChannelAction}
-					></r4-channel-actions>
+				></r4-channel-actions>
+
+				${this.isFollower ? html`<p>is-follower</p>` : html`<p>not-follower</p>`}
+				${this.isFollowed ? html`<p>is-followed</p>` : html`<p>not-followed</p>`}
 
 				<r4-channel-coordinates>
 					${ this.coordinates? this.renderMap() : null}

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -76,9 +76,9 @@ export default class R4PageChannel extends BaseChannel {
 					slot="dialog"
 					origin=${this.channelOrigin}
 					slug=${channel.slug}
-					></r4-channel-sharer>
-			</r4-dialog>
-		`
+	></r4-channel-sharer>
+	</r4-dialog>
+	`
 	}
 
 	renderMap() {
@@ -115,6 +115,12 @@ export default class R4PageChannel extends BaseChannel {
 			if (detail === 'update') {
 				page(`/${this.params.slug}/update`)
 			}
+			if (detail === 'followings') {
+				page(`/${this.params.slug}/followings`)
+			}
+			if (detail === 'followers') {
+				page(`/${this.params.slug}/followers`)
+			}
 			if (['share'].indexOf(detail) > -1) {
 				this.openDialog(detail)
 			}
@@ -141,7 +147,7 @@ export default class R4PageChannel extends BaseChannel {
 
 	closeDialog(name) {
 		const $dialog = this.querySelector(`r4-dialog[name="${name}"]`)
-		if ($dialog) {
+	if ($dialog) {
 			$dialog.removeAttribute('visible')
 		}
 	}

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -13,11 +13,6 @@ export default class R4PageChannel extends BaseChannel {
 		}
 	}
 
-	get alreadyFollowing() {
-		const followings = this.store.followings.map(c => c.channel_id.slug)
-		return followings.includes(this.channel.slug)
-	}
-
 	follow() {
 		const userChannel = this.store.userChannels.find(c => c.slug === this.config.selectedSlug)
 		return sdk.channels.followChannel(userChannel.id, this.channel.id)
@@ -35,10 +30,6 @@ export default class R4PageChannel extends BaseChannel {
 
 		return html`
 		<menu>
-			${this.alreadyFollowing ?
-				html`<button @click=${this.unfollow}>Unfollow</button>` :
-				html`<button @click=${this.follow}>Follow</button>`
-			}
 
 			<r4-page-actions>
 				<r4-channel-actions
@@ -47,8 +38,11 @@ export default class R4PageChannel extends BaseChannel {
 					@input=${this.onChannelAction}
 				></r4-channel-actions>
 
-				${this.isFollower ? html`<p>is-follower</p>` : html`<p>not-follower</p>`}
-				${this.isFollowed ? html`<p>is-followed</p>` : html`<p>not-followed</p>`}
+				${this.followsYou ? html`<p>follows you</p>` : html`<p>doesn't follow you</p>`}
+				${this.alreadyFollowing ?
+					html`<button @click=${this.unfollow}>Unfollow</button>` :
+					html`<button @click=${this.follow}>Follow</button>`
+				}
 
 				<r4-channel-coordinates>
 					${ this.coordinates? this.renderMap() : null}

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -14,11 +14,13 @@ export default class R4PageChannel extends BaseChannel {
 	}
 
 	follow() {
+		if (!this.store.user || !this.store.userChannels) return
 		const userChannel = this.store.userChannels.find(c => c.slug === this.config.selectedSlug)
 		return sdk.channels.followChannel(userChannel.id, this.channel.id)
 	}
 
 	unfollow() {
+		if (!this.store.user || !this.store.userChannels) return
 		const userChannel = this.store.userChannels.find(c => c.slug === this.config.selectedSlug)
 		return sdk.channels.unfollowChannel(userChannel.id, this.channel.id)
 	}

--- a/src/pages/r4-page-explore.js
+++ b/src/pages/r4-page-explore.js
@@ -1,4 +1,5 @@
 import {html, LitElement} from 'lit'
+import page from 'page/page.mjs'
 
 export default class R4PageExplore extends LitElement {
 	static properties = {
@@ -40,7 +41,7 @@ export default class R4PageExplore extends LitElement {
 		currentPage && newPageURL.searchParams.set('page', currentPage)
 
 		if (window.location.href !== newPageURL.href) {
-			history.replaceState({}, window.title, newPageURL.href)
+			page(newPageURL.pathname + newPageURL.search)
 		}
 	}
 }

--- a/src/pages/r4-page-home.js
+++ b/src/pages/r4-page-home.js
@@ -22,7 +22,7 @@ export default class R4PageHome extends LitElement {
 				${this.store?.userChannels?.length ? html`
 					<section>
 						<h2>Your channel follows:</h2>
-						${this.store?.followings?.map(({following_channel_id: channel}) => this.renderChannelCard(channel, this.config.href))}
+						${this.store?.followings?.map(({channel_id: channel}) => this.renderChannelCard(channel, this.config.href))}
 					</section>
 		` : null}
 			</main>

--- a/src/pages/r4-page-home.js
+++ b/src/pages/r4-page-home.js
@@ -15,9 +15,16 @@ export default class R4PageHome extends LitElement {
 				${this.store.user ? this.renderMenuUser() : this.renderMenuNoUser()}
 				${this.store?.userChannels?.length ? html`
 					<section>
+						<h2>You channel:</h2>
 						${this.store?.userChannels.map((channel) => this.renderChannelCard(channel, this.config.href))}
 					</section>
 				` : null}
+				${this.store?.userChannels?.length ? html`
+					<section>
+						<h2>Your channel follows:</h2>
+						${this.store?.followings?.map(({following_channel_id: channel}) => this.renderChannelCard(channel, this.config.href))}
+					</section>
+		` : null}
 			</main>
 		`
 	}

--- a/src/pages/r4-page-home.js
+++ b/src/pages/r4-page-home.js
@@ -22,7 +22,7 @@ export default class R4PageHome extends LitElement {
 				${this.store?.userChannels?.length ? html`
 					<section>
 						<h2>Your channel follows:</h2>
-						${this.store?.followings?.map(({channel_id: channel}) => this.renderChannelCard(channel, this.config.href))}
+						${this.store?.followings?.map((channel) => this.renderChannelCard(channel, this.config.href))}
 					</section>
 		` : null}
 			</main>

--- a/vite.config.js
+++ b/vite.config.js
@@ -69,6 +69,7 @@ export default defineConfig({
 				r4ChannelDelete: resolve(__dirname, 'examples/r4-channel-delete/index.html'),
 				r4ChannelSharer: resolve(__dirname, 'examples/r4-channel-sharer/index.html'),
 				r4ChannelUpdate: resolve(__dirname, 'examples/r4-channel-update/index.html'),
+				r4ChannelFollowers: resolve(__dirname, 'examples/r4-channel-followers/index.html'),
 				r4Channels: resolve(__dirname, 'examples/r4-channels/index.html'),
 				r4Dialog: resolve(__dirname, 'examples/r4-dialog/index.html'),
 				r4Favicon: resolve(__dirname, 'examples/r4-favicon/index.html'),

--- a/vite.config.js
+++ b/vite.config.js
@@ -70,6 +70,7 @@ export default defineConfig({
 				r4ChannelSharer: resolve(__dirname, 'examples/r4-channel-sharer/index.html'),
 				r4ChannelUpdate: resolve(__dirname, 'examples/r4-channel-update/index.html'),
 				r4ChannelFollowers: resolve(__dirname, 'examples/r4-channel-followers/index.html'),
+				r4ChannelFollowings: resolve(__dirname, 'examples/r4-channel-followings/index.html'),
 				r4Channels: resolve(__dirname, 'examples/r4-channels/index.html'),
 				r4Dialog: resolve(__dirname, 'examples/r4-dialog/index.html'),
 				r4Favicon: resolve(__dirname, 'examples/r4-favicon/index.html'),


### PR DESCRIPTION
introduce in the UI the concept of "followers" and "following"; this naming is temporary

Needs to be merged first:
- [x] https://github.com/radio4000/supabase/pull/10
- [x] https://github.com/radio4000/sdk/pull/16

Todo:
- [x] `npm link @radio4000/sdk` on branch `feat/channel-follow`
- [x] load `r4-app.state.{followers/following}`, depending on the `r4-app.{selectedSlug,selectedChannel}` (the user's UI channel to which everything in the UI is based on, including current followings/followers list)
- [x] show on `/` a list of the `r4-app.selectedChannel.followings`, so we could display "latest tracks" for each" (maybe even date, on "unread")
- [x] make it possible to follow a channel (with `this.selectedChannel.id` as the base for "follower")
- [x] make it possible to see who follows our channel (and keep this private info to us, in `/:slug/followers`)
- [x] make it possible to see who are the channels a channel follow in `/:slug/following`)

Not done:
- [ ] check privacy settings of `/:slug/followers` (and `/:slug/followings`), to be sure only the channel owner sees their followers
- [ ] wth is going on with the r4-list components, and all that extend it? multiple refreshes, not the correct data on load
- [ ] r4-channel-actions, do we really use that? shall it be refactored to something smarter?
- [ ] many more, this is so prototype level