### PR TITLE
r4-supabase-query

### DIFF
--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -24,6 +24,14 @@
 				flex-direction: row;
 				flex-wrap: wrap;
 			}
+			r4-supabase-query form fieldset {
+				display: inline;
+			}
+			r4-supabase-query form ul {
+				list-style: none;
+				display: flex;
+				flex-wrap: wrap;
+			}
 			textarea {
 				width: 100%;
 				min-width: 100%;

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -31,7 +31,8 @@
 					model,
 					select,
 					orderKey,
-					orderConfig
+					orderConfig,
+					filters,
 				} = detail
 
 				limit && searchParams.set('limit', limit)
@@ -39,6 +40,9 @@
 				model && searchParams.set('model', model)
 				select && searchParams.set('select', select)
 				orderKey && searchParams.set('orderKey', orderKey)
+				orderConfig && searchParams.set('orderConfig', JSON.stringify(orderConfig))
+				filters && searchParams.set('filters', JSON.stringify(filters))
+
 				window.location.searchParams = searchParams
 				console.log('searchParams', searchParams)
 			}

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -16,7 +16,7 @@
 				help build a query to supabase (via the js sdk) using <a href="https://supabase.com/docs/reference/javascript/using-filters">filters</a>
 			</li>
 		</menu>
-		<r4-supabase-query model="tracks" page="1" limit="1"></r4-supabase-query>
+		<r4-supabase-query></r4-supabase-query>
 
 		<script>
 			/* Handles a r4-supabase-query

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -13,7 +13,7 @@
 	<body>
 		<menu>
 			<li>
-				help build a query to supabase (via the js sdk)
+				help build a query to supabase (via the js sdk) using <a href="https://supabase.com/docs/reference/javascript/using-filters">filters</a>
 			</li>
 		</menu>
 		<r4-supabase-query model="tracks" page="1" limit="1"></r4-supabase-query>

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -15,6 +15,15 @@
 				flex-direction: column;
 				padding: 1rem;
 			}
+			r4-supabase-query {
+				display: flex;
+				flex-direction: column;
+			}
+			r4-supabase-query form {
+				display: flex;
+				flex-direction: row;
+				flex-wrap: wrap;
+			}
 		</style>
 	</head>
 

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -1,30 +1,77 @@
 <!DOCTYPE html>
 <html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" href="data:;base64,iVBORw0KGgo=">
+		<title>r4-supabase-query</title>
+		<meta name="description" content="r4-supabase-query">
+		<link rel="stylesheet" href="/styles/index.css" />
+		<script type="module" src="/src/index.js"></script>
+	</head>
 
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width">
-	<link rel="icon" href="data:;base64,iVBORw0KGgo=">
+	<body>
+		<menu>
+			<li>
+				help build a query to supabase (via the js sdk)
+			</li>
+		</menu>
+		<r4-supabase-query model="tracks" page="1" limit="1"></r4-supabase-query>
 
-	<title>r4-supabase-query</title>
-	<meta name="description" content="r4-supabase-query">
-	<link rel="stylesheet" href="/styles/index.css" />
-	<script type="module" src="/src/index.js"></script>
-</head>
+		<script>
+			/* Handles a r4-supabase-query
+				 this function, updates the page's URL, when there is an output
+			 */
+			function onQuery({ detail }) {
+				const searchParams = new URLSearchParams()
+				const {
+					list,
+					page,
+					limit,
+					model,
+					select,
+					orderKey,
+					orderConfig
+				} = detail
 
-<body>
-	<menu>
-		<li>
-			help build a query to supabase (via the js sdk)
-		</li>
-	</menu>
-	<r4-supabase-query model="tracks" page="1" limit="1"></r4-supabase-query>
+				limit && searchParams.set('limit', limit)
+				page && searchParams.set('page', page)
+				model && searchParams.set('model', model)
+				select && searchParams.set('select', select)
+				orderKey && searchParams.set('orderKey', orderKey)
+				window.location.searchParams = searchParams
+				console.log('searchParams', searchParams)
+			}
 
-	<script>
-		document.querySelector('r4-supabase-query').addEventListener('output', (event) => {
-			console.log('r4-supabase-query event', event.detail)
-		})
-	</script>
-</body>
+
+			/* Handles getting an initial "query" from the URLSearchParams
+				 this function, updates the r4-supabase-query web component,
+				 with initial value overwitting the components existing attributes
+			 */
+			function setUrlQueryOnComponent($el) {
+				const searchParams = new URLSearchParams(window.location.searchParams)
+				console.log('searchParams in URL', searchParams)
+				/* const {
+					 list,
+					 page,
+					 limit,
+					 model,
+					 select,
+					 orderKey,
+					 orderConfig
+					 } = detail */
+			}
+
+			/* initialize the example app:
+				 - get initial query from URLsearchparams
+				 - handle events from the query component */
+			const $r4Query = document.querySelector('r4-supabase-query')
+			setUrlQueryOnComponent($r4Query);
+			$r4Query.addEventListener('output', (event) => {
+				console.log('query output', event.detail)
+				onQuery(event)
+			});
+		</script>
+	</body>
 
 </html>

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -32,6 +32,9 @@
 			<li>
 				help build a query to supabase (via the js sdk) using <a href="https://supabase.com/docs/reference/javascript/using-filters">filters</a>
 			</li>
+			<li>
+				<a href="./">reset search</a> to default values (clears the query params)
+			</li>
 		</menu>
 
 		<r4-supabase-query></r4-supabase-query>
@@ -58,9 +61,10 @@
 				page && searchParams.set('page', page)
 				model && searchParams.set('model', model)
 				select && searchParams.set('select', select)
-				orderKey && searchParams.set('orderKey', orderKey)
-				orderConfig && searchParams.set('orderConfig', JSON.stringify(orderConfig))
 				filters && searchParams.set('filters', JSON.stringify(filters))
+				/* these two have a `-` mapping of their name */
+				orderKey && searchParams.set('order-key', orderKey)
+				orderConfig && searchParams.set('order-config', JSON.stringify(orderConfig))
 
 				console.log('searchParams', searchParams)
 				window.history.replaceState(null, null, `?${searchParams.toString()}`);
@@ -73,7 +77,7 @@
 			 */
 			function setUrlSearchOnComponent($el) {
 				const searchParams = new URLSearchParams(window.location.search)
-				const knownParams = ['list', 'page', 'limit', 'model', 'select', 'orderKey', 'orderConfig', 'filters']
+				const knownParams = ['list', 'page', 'limit', 'model', 'select', 'order-key', 'order-config', 'filters']
 				knownParams.forEach(param => {
 					if (searchParams.has(param)) {
 						$el.setAttribute(param, searchParams.get(param))

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -8,6 +8,14 @@
 		<meta name="description" content="r4-supabase-query">
 		<link rel="stylesheet" href="/styles/index.css" />
 		<script type="module" src="/src/index.js"></script>
+
+		<style>
+			output {
+				display: flex;
+				flex-direction: column;
+				padding: 1rem;
+			}
+		</style>
 	</head>
 
 	<body>
@@ -16,13 +24,15 @@
 				help build a query to supabase (via the js sdk) using <a href="https://supabase.com/docs/reference/javascript/using-filters">filters</a>
 			</li>
 		</menu>
+
 		<r4-supabase-query></r4-supabase-query>
+		<output></output>
 
 		<script>
 			/* Handles a r4-supabase-query
 				 this function, updates the page's URL, when there is an output
 			 */
-			function onQuery({ detail }) {
+			function setQueryToUrlSearch({ detail }) {
 				const searchParams = new URLSearchParams()
 				const {
 					list,
@@ -52,7 +62,7 @@
 				 this function, updates the r4-supabase-query web component,
 				 with initial value overwitting the components existing attributes
 			 */
-			function setUrlQueryOnComponent($el) {
+			function setUrlSearchOnComponent($el) {
 				const searchParams = new URLSearchParams(window.location.search)
 				const knownParams = ['list', 'page', 'limit', 'model', 'select', 'orderKey', 'orderConfig', 'filters']
 				knownParams.forEach(param => {
@@ -66,10 +76,10 @@
 				 - get initial query from URLsearchparams
 				 - handle events from the query component */
 			const $r4Query = document.querySelector('r4-supabase-query')
-			setUrlQueryOnComponent($r4Query);
+			setUrlSearchOnComponent($r4Query);
 			$r4Query.addEventListener('output', (event) => {
-				console.log('query output', event.detail)
-				onQuery(event)
+				setQueryToUrlSearch(event)
+				document.querySelector('output').innerText = JSON.stringify(event.detail.data)
 			});
 		</script>
 	</body>

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
+	<link rel="icon" href="data:;base64,iVBORw0KGgo=">
+
+	<title>r4-supabase-query</title>
+	<meta name="description" content="r4-supabase-query">
+	<link rel="stylesheet" href="/styles/index.css" />
+	<script type="module" src="/src/index.js"></script>
+</head>
+
+<body>
+	<menu>
+		<li>
+			help build a query to supabase (via the js sdk)
+		</li>
+	</menu>
+	<r4-supabase-query model="tracks" page="1" limit="1"></r4-supabase-query>
+
+	<script>
+		document.querySelector('r4-supabase-query').addEventListener('output', (event) => {
+			console.log('r4-supabase-query event', event.detail)
+		})
+	</script>
+</body>
+
+</html>

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -43,8 +43,8 @@
 				orderConfig && searchParams.set('orderConfig', JSON.stringify(orderConfig))
 				filters && searchParams.set('filters', JSON.stringify(filters))
 
-				window.location.searchParams = searchParams
 				console.log('searchParams', searchParams)
+				window.history.replaceState(null, null, `?${searchParams.toString()}`);
 			}
 
 
@@ -53,17 +53,13 @@
 				 with initial value overwitting the components existing attributes
 			 */
 			function setUrlQueryOnComponent($el) {
-				const searchParams = new URLSearchParams(window.location.searchParams)
-				console.log('searchParams in URL', searchParams)
-				/* const {
-					 list,
-					 page,
-					 limit,
-					 model,
-					 select,
-					 orderKey,
-					 orderConfig
-					 } = detail */
+				const searchParams = new URLSearchParams(window.location.search)
+				const knownParams = ['list', 'page', 'limit', 'model', 'select', 'orderKey', 'orderConfig', 'filters']
+				knownParams.forEach(param => {
+					if (searchParams.has(param)) {
+						$el.setAttribute(param, searchParams.get(param))
+					}
+				})
 			}
 
 			/* initialize the example app:

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -24,6 +24,11 @@
 				flex-direction: row;
 				flex-wrap: wrap;
 			}
+			textarea {
+				width: 100%;
+				min-width: 100%;
+				min-height: 10rem;
+			}
 		</style>
 	</head>
 
@@ -38,7 +43,7 @@
 		</menu>
 
 		<r4-supabase-query></r4-supabase-query>
-		<output></output>
+		<textarea id="result" readonly></textarea>
 
 		<script>
 			/* Handles a r4-supabase-query
@@ -92,7 +97,7 @@
 			setUrlSearchOnComponent($r4Query);
 			$r4Query.addEventListener('output', (event) => {
 				setQueryToUrlSearch(event)
-				document.querySelector('output').innerText = JSON.stringify(event.detail.data)
+				document.querySelector('#result').innerText = JSON.stringify(event.detail.data)
 			});
 		</script>
 	</body>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -33,6 +33,7 @@ import {R4ChannelSearch, R4TrackSearch} from './r4-search.js'
 import R4SignIn from './r4-sign-in.js'
 import R4SignOut from './r4-sign-out.js'
 import R4SignUp from './r4-sign-up.js'
+import R4SupabaseQuery from './r4-supabase-query.js'
 import R4Title from './r4-title.js'
 import R4Track from './r4-track.js'
 import R4TrackActions from './r4-track-actions.js'
@@ -77,6 +78,7 @@ customElements.define('r4-router', R4Router)
 customElements.define('r4-sign-in', R4SignIn)
 customElements.define('r4-sign-out', R4SignOut)
 customElements.define('r4-sign-up', R4SignUp)
+customElements.define('r4-supabase-query', R4SupabaseQuery)
 customElements.define('r4-title', R4Title)
 customElements.define('r4-track', R4Track)
 customElements.define('r4-track-actions', R4TrackActions)
@@ -122,6 +124,7 @@ export default {
 	R4SignIn,
 	R4SignOut,
 	R4SignUp,
+	R4SupabaseQuery,
 	R4Title,
 	R4Track,
 	R4TrackActions,

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -265,14 +265,18 @@ export default class R4SupabaseQuery extends LitElement {
 				${[
 					this.renderQueryModel(),
 					this.renderQuerySelect(),
-					this.renderQuerySelectDisplay(),
 					this.renderQueryPage(),
 					this.renderQueryLimit(),
 					this.renderQueryOrderKey(),
 					this.renderOrderConfig(),
 				]}
 			</form>
-			<form @submit=${this.onFormSubmit}>${this.renderFilters()}</form>
+			<form @submit=${this.onFormSubmit}>
+				${this.filters.length ? this.renderFilters() : null}
+				<fieldset>
+					<button @click=${this.addFilter}>Add filter</button>
+				</fieldset>
+			</form>
 		`
 	}
 	renderQueryModel() {
@@ -298,13 +302,6 @@ export default class R4SupabaseQuery extends LitElement {
 					</optgroup>
 					${this.renderQuerySelectByModel()}
 				</select>
-			</fieldset>
-		`
-	}
-	renderQuerySelectDisplay() {
-		return html`
-			<fieldset>
-				<label for="select-display">select(ing)</label>
 				<input id="select-display" name="select" @input=${this.onInput} disabled type="text"
 					.value=${this.select} placeholder="postgresql select"></input>
 			</fieldset>
@@ -380,34 +377,41 @@ export default class R4SupabaseQuery extends LitElement {
 			`
 		}
 
-		return html`
-			${this.filters ? this.filters.map(renderFilterItem.bind(this)) : null}
-			<button @click=${this.addFilter}>Add filter</button>
-		`
+		return html`<ul>
+			${this.filters.map(renderFilterItem.bind(this))}
+		</ul>`
 	}
 
 	renderFilter(filter, index) {
 		return html`
-			<label>
-				Operator
-				<select @input=${(e) => this.updateFilter(index, 'operator', e.target.value)} .value=${filter.operator}>
-					${supabaseOperators.map((operator) => html`<option .value=${operator}>${operator}</option>`)}
-				</select>
-			</label>
+			<fieldset>
+				<label>
+					Operator
+					<select @input=${(e) => this.updateFilter(index, 'operator', e.target.value)} .value=${filter.operator}>
+						${supabaseOperators.map((operator) => html`<option .value=${operator}>${operator}</option>`)}
+					</select>
+				</label>
+			</fieldset>
 
-			<label>
-				Column
-				<input
-					type="text"
-					@input=${(e) => this.updateFilter(index, 'column', e.target.value)}
-					.value=${filter.column}
-				/>
-			</label>
+			<fieldset>
+				<label>
+					Column
+					<select @input=${(e) => this.updateFilter(index, 'column', e.target.value)} .value=${filter.column}>
+						${this.model ? supabaseTables[this.model].columns.map(this.renderOption) : null}
+					</select>
+				</label>
+			</fieldset>
 
-			<label>
-				Value
-				<input type="text" @input=${(e) => this.updateFilter(index, 'value', e.target.value)} .value=${filter.value} />
-			</label>
+			<fieldset>
+				<label>
+					Value
+					<input
+						type="text"
+						@input=${(e) => this.updateFilter(index, 'value', e.target.value)}
+						.value=${filter.value}
+					/>
+				</label>
+			</fieldset>
 		`
 	}
 

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -5,9 +5,23 @@ import {LitElement, html} from 'lit'
 	 (query params ->) components-attributes -> supbase-query
 	 this does not render the list, just browses it
  */
-async function browsePage({page, limit, model, select, orderKey, orderConfig}) {
+async function buildBrowsePageQuery({
+	page = 1,
+	limit = 1,
+	model = '',
+	select = '',
+	orderKey = '',
+	orderConfig = {},
+	filters = [],
+}) {
 	const {from, to, limitResults} = getBrowseParams({page, limit})
-	return sdk.supabase.from(model).select(select).limit(limitResults).order(orderKey, orderConfig).range(from, to)
+	let query = sdk.supabase.from(model).select(select).limit(limitResults).order(orderKey, orderConfig).range(from, to)
+
+	/* add filters to the query */
+	filters.forEach((filter) => {
+		query = query.filter(filter.column, filter.operator, filter.value)
+	})
+	return query
 }
 
 /*
@@ -35,26 +49,27 @@ export default class R4SupabaseQuery extends LitElement {
 		limit: {type: Number, reflect: true},
 
 		/* supabase query parameters */
-		model: {type: String},
-		orderKey: {type: String, attribute: 'order-key'},
-		select: {type: String},
-		orderConfig: {type: Object},
+		model: {type: String, reflect: true},
+		orderKey: {type: String, attribute: 'order-key', reflect: true},
+		select: {type: String, reflect: true},
+		filters: {type: Array, reflect: true},
+		orderConfig: {type: Object, reflect: true, state: true},
 
-		/* are we loading data? */
-		loading: {type: Boolean},
 		/* the list of items, result of the query for this model, page & limit */
 		list: {type: Object},
 	}
+
 	constructor() {
 		super()
-		this.page = null
-		this.limit = null
-		this.model = ''
+		/* all need to be instanciated with correct "value types" */
+		this.model = null
+		this.page = 1
+		this.limit = 10
 		this.orderKey = 'created_at'
-		this.select = 'id'
-		this.orderConfig = {ascending: true}
-		this.loading = false
+		this.select = '*'
+		this.orderConfig = {ascending: false}
 		this.list = null
+		this.filters = []
 	}
 
 	/* the number of items in the list  */
@@ -92,17 +107,23 @@ export default class R4SupabaseQuery extends LitElement {
 
 	async willUpdate(attrName) {
 		if (!attrName.has('list')) this.updateList()
+		/* maybe cleanup some attributes, if the model changes? */
 	}
 
 	async updateList() {
-		const res = await browsePage({
+		if (!this.model) return
+		const query = buildBrowsePageQuery({
 			page: this.page,
 			limit: this.limit,
 			model: this.model,
 			select: this.select,
 			orderKey: this.orderKey,
 			orderConfig: this.orderConfig,
+			filters: this.filters,
 		})
+
+		const res = await query
+
 		if (res) {
 			this.list = res.data
 		} else {
@@ -112,9 +133,14 @@ export default class R4SupabaseQuery extends LitElement {
 		const listEvent = new CustomEvent('output', {
 			bubbles: true,
 			detail: {
+				list: this.list,
 				page: this.page,
 				limit: this.limit,
-				list: this.list,
+				model: this.model,
+				select: this.select,
+				orderKey: this.orderKey,
+				orderConfig: this.orderConfig,
+				filters: this.filters,
 			},
 		})
 		this.dispatchEvent(listEvent)
@@ -135,9 +161,14 @@ export default class R4SupabaseQuery extends LitElement {
 	onInput(event) {
 		event.stopPropagation()
 		event.preventDefault()
-		const {name, value} = event.target
-		if (name === 'ascending') {
-			this.orderConfig[name] = value
+		const {name, value, valueAsNumber, type: inputType, checked} = event.target
+
+		/* handle correctly input type="number" */
+		if (inputType === 'number') {
+			this[name] = valueAsNumber
+		} else if (name === 'ascending') {
+			/* this is a input[checkbox] and setting, inside a nested Object */
+			this.orderConfig = {...this.orderConfig, [name]: checked}
 		} else if (name) {
 			this[name] = value
 		}
@@ -153,34 +184,147 @@ export default class R4SupabaseQuery extends LitElement {
 	renderQueryBuilder() {
 		return html`
 			<form>
-				<select name="model" @input=${this.onInput} value=${this.model}>
-					<option default disabled>${this.model}</option>
+				${[
+					this.renderQueryModel(),
+					this.renderQuerySelect(),
+					this.renderQuerySelectDisplay(),
+					this.renderQueryPage(),
+					this.renderQueryLimit(),
+					this.renderQueryOrderKey(),
+					this.renderOrderConfig(),
+				]}
+			</form>
+			<output> ${JSON.stringify(this.list)} </output>
+		`
+	}
+	renderQueryModel() {
+		return html`
+			<fieldset>
+				<label for="model">model</label>
+				<select id="model" name="model" @input=${this.onInput} .value=${this.model}>
+					<optgroup disabled>
+						<option default>${this.model}</option>
+					</optgroup>
 					<option value="channels">channels</option>
 					<option value="tracks">tracks</option>
+					<option value="channel_track">channel_track</option>
 				</select>
-				<select name="select" @input=${this.onInput} value=${this.select}>
-					<option default value="id">id</option>
-					<option value="*">*</option>
-				</select>
-				<input name="select" @input=${this.onInput} disabled type="text" value=${this.select}
-							 placeholder="postgresql select"></input>
-				<input name="page" @input=${this.onInput} type="number"
-							 value=${this.page} min=${0}
-							 placeholder="page"></input>
-				<input name="limit" @input=${this.onInput} type="number"
-							 value=${this.limit} min=${0}
-							 placeholder="limit"></input>
-				<select name="orderKey" @input=${this.onInput} value=${this.orderKey}>
-					<option default disabled>${this.orderKey}</option>
-					<option value="title">title</option>
-					<option value="created_at">created_at</option>
-				</select>
-				<input name="ascending" @input=${this.onInput} type="radio"
-							 value=${this.orderConfig?.ascending}></input>
-			</form>
-			<output>
-				${JSON.stringify(this.list)}
-			</output>
+			</fieldset>
 		`
+	}
+	renderQuerySelect() {
+		return html`
+			<fieldset>
+				<label for="select">sql-select-query</label>
+				<select id="select" name="select" @input=${this.onInput} .value=${this.select}>
+					<optgroup disabled>
+						<option default>${this.select}</option>
+					</optgroup>
+					${this.renderQuerySelectByModel()}
+				</select>
+			</fieldset>
+		`
+	}
+	renderQuerySelectDisplay() {
+		return html`
+			<fieldset>
+				<label for="select-display">limit</label>
+				<input id="select-display" name="select" @input=${this.onInput} disabled type="text"
+					.value=${this.select} placeholder="postgresql select"></input>
+			</fieldset>
+		`
+	}
+	renderQueryPage() {
+		return html`
+			<fieldset>
+				<label for="page">page</label>
+				<input id="page" name="page" @input=${this.onInput} type="number"
+					.value=${this.page} step="1" placeholder="page"></input>
+			</fieldset>
+		`
+	}
+	renderQueryLimit() {
+		return html`
+			<fieldset>
+				<label for="limit">limit</label>
+				<input id="limit" name="limit" @input=${this.onInput} type="number"
+					.value=${this.limit} placeholder="limit"></input>
+			</fieldset>
+		`
+	}
+	renderQueryOrderKey() {
+		return html`
+			<fieldset>
+				<label for="orderKey">order-key</label>
+				<select id="oderKey" name="orderKey" @input=${this.onInput} .value=${this.orderKey}>
+					<optgroup disabled>
+						<option default>${this.orderKey}</option>
+					</optgroup>
+					${this.renderQueryOrderKeyByModel()}
+				</select>
+			</fieldset>
+		`
+	}
+	renderOrderConfig() {
+		const {ascending} = this.orderConfig
+		return html`
+			<fieldset>
+				<label for="ascending">
+					${ascending ? '↑' : '↓'}
+				</label>
+				<input id="ascending" name="ascending" @input=${this.onInput} type="checkbox"
+					.checked=${ascending}></input>
+			</fieldset>
+		`
+	}
+
+	/* different order keys for each models */
+	renderQueryOrderKeyByModel() {
+		const options = {
+			/* [{"id":"e69ed566-f1ba-475f-932a-253703e01913","name":"Atakat","slug":"atakatttt","description":"my test channel","url":null,"image":"r76nxlqqbici6hz49vkr","created_at":"2023-04-13T09:52:47.315206+00:00","updated_at":"2023-05-18T18:56:44.76163+00:00","coordinates":null,"longitude":8.73284,"latitude":56.8233,"fts":"'atakat':1 'atakatttt':2 'channel':5 'test':4","favorites":null,"followers":null,"firebase_id":null}] */
+			channels: html`
+				<option default value="updated_at">updated_at</option>
+				<option value="created_at">created_at</option>
+				<option value="name">name</option>
+				<option value="description">description</option>
+				<option value="coordinates">coordinates</option>
+				<option value="firebase_id">firebase_id</option>
+				<option value="url">url</option>
+				<option value="id">id</option>
+			`,
+			tracks: html`
+				<option default value="updated_at">updated_at</option>
+				<option value="created_at">created_at</option>
+				<option value="title">title</option>
+				<option default value="discogs_url">discogs_url</option>
+				<option default value="description">description</option>
+				<option default value="tags">tags</option>
+				<option default value="mentions">mentions</option>
+				<option value="id">id</option>
+			`,
+			channel_track: html`
+				<option default value="created_at">created_at</option>
+				<option value="updated_at">updated_at</option>
+				<option value="user_id">user_id</option>
+				<option value="channel_id">channel_id</option>
+				<option value="track_id">track_id</option>
+			`,
+		}
+		return options[this.model] || null
+	}
+
+	renderQuerySelectByModel() {
+		const options = {
+			default: html`
+				<option default value="*">*</option>
+				<option value="id">id</option>
+			`,
+			channel_track: html`
+				<option default value="channel_id!inner(slug), track_id(id, created_at, updated_at, title, url, description)">
+					channel_id!inner(slug), track_id(id, created_at, updated_at, title, description, url, discogs_url)
+				</option>
+			`,
+		}
+		return options[this.model] || options['default']
 	}
 }

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -167,7 +167,8 @@ export default class R4SupabaseQuery extends LitElement {
 
 	async willUpdate(attrName) {
 		if (!attrName.has('list')) this.updateList()
-		/* maybe cleanup some attributes, if the model changes? */
+
+		if (!attrName.has('model')) this.cleanQuery(this.model)
 	}
 
 	async updateList() {
@@ -183,17 +184,13 @@ export default class R4SupabaseQuery extends LitElement {
 		})
 
 		const res = await query
-
-		if (res) {
-			this.list = res.data
-		} else {
-			/* this.list = [] */
-		}
+		const {data, error} = res
 
 		const listEvent = new CustomEvent('output', {
 			bubbles: true,
 			detail: {
-				list: this.list,
+				data,
+				error,
 				page: this.page,
 				limit: this.limit,
 				model: this.model,
@@ -252,6 +249,9 @@ export default class R4SupabaseQuery extends LitElement {
 		this.filters = newFilters
 	}
 
+	/* "resets" the components attributes, when the model change */
+	cleanQuery() {}
+
 	createRenderRoot() {
 		return this
 	}
@@ -273,7 +273,6 @@ export default class R4SupabaseQuery extends LitElement {
 				]}
 			</form>
 			<form @submit=${this.onFormSubmit}>${this.renderFilters()}</form>
-			<output>${JSON.stringify(this.list)}</output>
 		`
 	}
 	renderQueryModel() {

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -45,11 +45,11 @@ const supabaseOperators = Object.keys(supabaseOperatorsTable)
 
 const supabaseTables = {
 	channels: {
-		columns: ['created_at', 'updated_at', 'slug', 'name', 'description', 'coordinates', 'url', 'firebase', 'id'],
+		columns: ['created_at', 'updated_at', 'slug', 'name', 'description', 'coordinates', 'url', 'firebase', 'id', 'fts'],
 		selects: ['*', 'id'],
 	},
 	tracks: {
-		columns: ['created_at', 'updated_at', 'title', 'description', 'url', 'discogs_url', 'mentions', 'tags', 'id'],
+		columns: ['created_at', 'updated_at', 'title', 'description', 'url', 'discogs_url', 'mentions', 'tags', 'id', 'fts'],
 		selects: ['*', 'id'],
 	},
 	channel_track: {

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -377,7 +377,7 @@ export default class R4SupabaseQuery extends LitElement {
 					</optgroup>
 					${this.renderQuerySelectByModel()}
 				</select>
-				<input id="select-display" name="select" @input=${this.onInput} disabled type="text"
+				<input id="select-display" name="select" @input=${this.onInput} type="text"
 					.value=${this.select} placeholder="postgresql select"></input>
 			</fieldset>
 		`

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -110,7 +110,7 @@ async function buildBrowsePageQuery({
 			if (filter.operator === 'filter') {
 				query = query.filter(filter.operator, filter.column, filter.value || null)
 			} else if (['contains', 'containedBy'].includes(filter.operator)) {
-				query = query[filter.operator](filter.column, valueJson || filter.value || null)
+				query = query[filter.operator](filter.column, valueJson || [filter.value.split(',')] || null)
 			} else {
 				query = query[filter.operator](filter.column, filter.value || null)
 			}

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -49,7 +49,18 @@ const supabaseTables = {
 		selects: ['*', 'id'],
 	},
 	tracks: {
-		columns: ['created_at', 'updated_at', 'title', 'description', 'url', 'discogs_url', 'mentions', 'tags', 'id', 'fts'],
+		columns: [
+			'created_at',
+			'updated_at',
+			'title',
+			'description',
+			'url',
+			'discogs_url',
+			'mentions',
+			'tags',
+			'id',
+			'fts',
+		],
 		selects: ['*', 'id'],
 	},
 	channel_track: {
@@ -59,7 +70,9 @@ const supabaseTables = {
 	},
 }
 /* build the channel_track default select, from all "tracks" columns */
-supabaseTables['channel_track'].selects.push(`channel_id(slug),track_id(${supabaseTables.tracks.columns.join(',')})`)
+supabaseTables['channel_track'].selects.push(
+	`channel_id!inner(slug),track_id!inner(${supabaseTables.tracks.columns.join(',')})`
+)
 
 /* build the channel_track "juction columns", from all "tracks" columns */
 const channelTrackJuctionColumns = supabaseTables.tracks.columns.map((column) => `track_id.${column}`)

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -1,0 +1,186 @@
+import {sdk} from '@radio4000/sdk'
+import {LitElement, html} from 'lit'
+
+/* browse the list (of data models) like it is paginated;
+	 (query params ->) components-attributes -> supbase-query
+	 this does not render the list, just browses it
+ */
+async function browsePage({page, limit, model, select, orderKey, orderConfig}) {
+	const {from, to, limitResults} = getBrowseParams({page, limit})
+	return sdk.supabase.from(model).select(select).limit(limitResults).order(orderKey, orderConfig).range(from, to)
+}
+
+/*
+	 converts web component attributes, to supabase sdk query parameters:
+	 -> page="1" limit="1"
+	 -> from[0] to to[0] limit[0]
+ */
+function getBrowseParams({page, limit}) {
+	let from, to, limitResults
+	from = (page - 1) * limit
+	to = from + limit - 1
+	limitResults = limit - 1
+	return {from, to, limitResults}
+}
+
+/*
+	 list-channels, default `page="1"`, `limit="1"`;
+	 its attributes are bound to the supabase sdk model query values
+ */
+export default class R4SupabaseQuery extends LitElement {
+	upperLimit = 999
+
+	static properties = {
+		page: {type: Number, reflect: true},
+		limit: {type: Number, reflect: true},
+
+		/* supabase query parameters */
+		model: {type: String},
+		orderKey: {type: String, attribute: 'order-key'},
+		select: {type: String},
+		orderConfig: {type: Object},
+
+		/* are we loading data? */
+		loading: {type: Boolean},
+		/* the list of items, result of the query for this model, page & limit */
+		list: {type: Object},
+	}
+	constructor() {
+		super()
+		this.page = null
+		this.limit = null
+		this.model = ''
+		this.orderKey = 'created_at'
+		this.select = 'id'
+		this.orderConfig = {ascending: true}
+		this.loading = false
+		this.list = null
+	}
+
+	/* the number of items in the list  */
+	/* get limit() {
+		 const attr = parseFloat(this.getAttribute('limit'))
+		 if (!attr || attr <= 0) {
+		 return 1
+		 } else if (attr > this.upperLimit) {
+		 return this.upperLimit
+		 } else {
+		 return attr
+		 }
+		 } */
+	/* current page number being browsed */
+	/* get page() {
+		 const attr = parseFloat(this.getAttribute('page'))
+		 if (!attr || attr <= 0) {
+		 return 1
+		 } else {
+		 return attr
+		 }
+		 }
+		 set page(digit) {
+		 if (digit) {
+		 this.setAttribute('page', parseFloat(digit))
+		 } else {
+		 this.removeAttribute('page')
+		 }
+		 } */
+
+	connectedCallback() {
+		super.connectedCallback()
+		this.updateList()
+	}
+
+	async willUpdate(attrName) {
+		if (!attrName.has('list')) this.updateList()
+	}
+
+	async updateList() {
+		const res = await browsePage({
+			page: this.page,
+			limit: this.limit,
+			model: this.model,
+			select: this.select,
+			orderKey: this.orderKey,
+			orderConfig: this.orderConfig,
+		})
+		if (res) {
+			this.list = res.data
+		} else {
+			/* this.list = [] */
+		}
+
+		const listEvent = new CustomEvent('output', {
+			bubbles: true,
+			detail: {
+				page: this.page,
+				limit: this.limit,
+				list: this.list,
+			},
+		})
+		this.dispatchEvent(listEvent)
+	}
+
+	/* calculate the index of a list item globally,
+		 for the current page/limit/ul.index;
+		 itemCurrentListIndex, is indexed 0 (`<li>` element) */
+	itemIndex(itemCurrentListIndex) {
+		if (this.page === 1) {
+			return this.page + itemCurrentListIndex
+		} else {
+			const startAt = (this.page - 1) * this.limit
+			return startAt + itemCurrentListIndex + 1 // initial is `0`
+		}
+	}
+
+	onInput(event) {
+		event.stopPropagation()
+		event.preventDefault()
+		const {name, value} = event.target
+		if (name === 'ascending') {
+			this.orderConfig[name] = value
+		} else if (name) {
+			this[name] = value
+		}
+	}
+
+	createRenderRoot() {
+		return this
+	}
+	render() {
+		return this.renderQueryBuilder()
+	}
+
+	renderQueryBuilder() {
+		return html`
+			<form>
+				<select name="model" @input=${this.onInput} value=${this.model}>
+					<option default disabled>${this.model}</option>
+					<option value="channels">channels</option>
+					<option value="tracks">tracks</option>
+				</select>
+				<select name="select" @input=${this.onInput} value=${this.select}>
+					<option default value="id">id</option>
+					<option value="*">*</option>
+				</select>
+				<input name="select" @input=${this.onInput} disabled type="text" value=${this.select}
+							 placeholder="postgresql select"></input>
+				<input name="page" @input=${this.onInput} type="number"
+							 value=${this.page} min=${0}
+							 placeholder="page"></input>
+				<input name="limit" @input=${this.onInput} type="number"
+							 value=${this.limit} min=${0}
+							 placeholder="limit"></input>
+				<select name="orderKey" @input=${this.onInput} value=${this.orderKey}>
+					<option default disabled>${this.orderKey}</option>
+					<option value="title">title</option>
+					<option value="created_at">created_at</option>
+				</select>
+				<input name="ascending" @input=${this.onInput} type="radio"
+							 value=${this.orderConfig?.ascending}></input>
+			</form>
+			<output>
+				${JSON.stringify(this.list)}
+			</output>
+		`
+	}
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
-import { resolve } from 'path'
-import { defineConfig } from 'vite'
+import {resolve} from 'path'
+import {defineConfig} from 'vite'
 
 /* treat the path '/examples/r4-app.html/' as SPA (serve the file, let js handle URL route) */
 const vitePluginR4AppSPA = (options) => ({
@@ -7,7 +7,7 @@ const vitePluginR4AppSPA = (options) => ({
 	configureServer(server) {
 		server.middlewares.use((req, res, next) => {
 			/* make a tmp URL */
-			const { pathname } = new URL('https://localhost' + req.originalUrl)
+			const {pathname} = new URL('https://localhost' + req.originalUrl)
 			if (pathname.startsWith('/examples/r4-app/')) {
 				req.url = '/examples/r4-app/'
 			}
@@ -56,6 +56,7 @@ export default defineConfig({
 				r4ButtonPlay: resolve(__dirname, 'examples/r4-button-play/index.html'),
 				r4ResetPassword: resolve(__dirname, 'examples/r4-reset-password/index.html'),
 				r4Router: resolve(__dirname, 'examples/r4-router/index.html'),
+				r4SupabaseQuery: resolve(__dirname, 'examples/r4-supabase-query/index.html'),
 				r4ChannelSearch: resolve(__dirname, 'examples/r4-channel-search/index.html'),
 				r4TrackSearch: resolve(__dirname, 'examples/r4-track-search/index.html'),
 				r4SignIn: resolve(__dirname, 'examples/r4-sign-in/index.html'),


### PR DESCRIPTION
attempt to make a "query builder" for r4 data

objectives:
- use supabase sdk to make a query to postgrest/postgres/sql, r4 tables
- create a web component UI to "build these queries", and therefore be able to browse/filter the data (all channels, all tracks, one channel's tracks, etc.)
- this component should not render the data, just "query allow the user to granularely query it" to the "backend"
- each time the user query is updated, the component should fetch the data, and emit an event with it; so a parent component can render it
- each time the user query is updated, it should "provide the means" to the parent component, to be able to updated the URL query parameter. That way, on page refresh, or current URL share, a user would load the exact same data.
- the data is passed from `URL search params → web components [attributes] → r4/supabase sdk → postgre(ql,st)`

wdyt?

- Not sure how abstract and generic it should/can be?
- maybe there is a clean way to select which model's attribute/key to filter on
- does it break "data down, action up"? should the data come from the route?

It feels maybe this component should not import the sdk; and have the "query function" up

todo:
- [x] make it work for default `/explore` and `/tracks`
- [x] `/:slug/explore`

thanks @Lperreau for the sqlhelp
