### PR TITLE
Add query count

### DIFF
--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -38,9 +38,10 @@ export default class R4SupabaseQuery extends LitElement {
 	}
 
 	updated(attr) {
-		/* always update the list when any attribute change
-			 for some attribute, first clear the existing search query */
 		if (attr.get('table')) this.cleanQuery()
+		// Avoid double-fetch when count is passed back down.
+		if (attr.get('count') === 0) return
+		// Update the list when any attribute changes
 		this.onQuery()
 	}
 

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -18,6 +18,13 @@ export default class R4SupabaseQuery extends LitElement {
 		filters: {type: Array, searchParam: true, reflect: true},
 		orderBy: {type: String, attribute: 'order-by', reflect: true, searchParam: true},
 		orderConfig: {type: Object, attribute: 'order-config', reflect: true, searchParam: true},
+
+		count: {type: Number}
+	}
+
+	get totalPages() {
+		console.log(this.count, this.limit)
+		return Math.round(this.count / this.limit) + 1
 	}
 
 	constructor() {
@@ -204,9 +211,10 @@ export default class R4SupabaseQuery extends LitElement {
 					.value=${this.page}
 					step="1"
 					min="1"
+					max=${this.totalPages}
 					pattern="[0-9]"
 					placeholder="page"
-				/>
+				/>/${this.totalPages}
 			</fieldset>
 		`
 	}

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -11,6 +11,7 @@ export default class R4SupabaseQuery extends LitElement {
 	static properties = {
 		page: {type: Number, reflect: true, searchParam: true},
 		limit: {type: Number, reflect: true, searchParam: true},
+		count: {type: Number},
 
 		/* supabase query parameters */
 		table: {type: String, reflect: true, searchParam: true},
@@ -18,12 +19,9 @@ export default class R4SupabaseQuery extends LitElement {
 		filters: {type: Array, searchParam: true, reflect: true},
 		orderBy: {type: String, attribute: 'order-by', reflect: true, searchParam: true},
 		orderConfig: {type: Object, attribute: 'order-config', reflect: true, searchParam: true},
-
-		count: {type: Number}
 	}
 
 	get totalPages() {
-		console.log(this.count, this.limit)
 		return Math.round(this.count / this.limit) + 1
 	}
 
@@ -118,7 +116,6 @@ export default class R4SupabaseQuery extends LitElement {
 		 is triggered before invoquing "onQuery"*/
 	cleanQuery() {
 		this.page = 1
-		/* this.limit = this.limit // stay unchanged? */
 
 		if (!this.table) {
 			// handle the case where there is no table selected; to display no result problably, or error

--- a/src/libs/browse.js
+++ b/src/libs/browse.js
@@ -54,7 +54,8 @@ export async function query({
 	orderConfig = {},
 	filters = [],
 }) {
-	let query = supabase.from(table).select('*', {count: 'exact', head: false})
+	// We add count exact: to get a .total property back in the response. head:false ensures we still get the rows.
+	let query = supabase.from(table).select(select, {count: 'exact', head: false})
 
 	/*
 		 add filters to the query,

--- a/src/libs/browse.js
+++ b/src/libs/browse.js
@@ -54,7 +54,7 @@ export async function query({
 	orderConfig = {},
 	filters = [],
 }) {
-	let query = supabase.from(table).select(select)
+	let query = supabase.from(table).select('*', {count: 'exact', head: false})
 
 	/*
 		 add filters to the query,
@@ -104,7 +104,7 @@ export async function query({
 	const {from, to, limit: l} = getBrowseParams({page, limit})
 	query = query.range(from, to).limit(l)
 
-	console.log('browse.query', {table, select, filters, orderBy, orderConfig, from, to, limit: l}, query.url.href)
+	console.log('browse.query', query.url.href, {table, select, filters, orderBy, orderConfig, from, to, limit: l})
 
 	return query
 }

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -15,6 +15,7 @@ export default class BaseChannel extends LitElement {
 		params: {type: Object, state: true},
 		store: {type: Object, state: true},
 		config: {type: Object, state: true},
+		searchParams: {type: Object, state: true},
 	}
 
 	get slug() {

--- a/src/pages/r4-page-channel-tracks.js
+++ b/src/pages/r4-page-channel-tracks.js
@@ -96,6 +96,7 @@ export default class R4PageChannelTracks extends BaseChannel {
 					filters=${params.get('filters')}
 					@query=${this.onQuery}
 				></r4-supabase-query>
+				<p>Found ${this.count} tracks</p>
 			</details>
 		`
 	}

--- a/src/pages/r4-page-channel-tracks.js
+++ b/src/pages/r4-page-channel-tracks.js
@@ -18,6 +18,8 @@ export default class R4PageChannelTracks extends BaseChannel {
 		channel: {type: Object, reflect: true, state: true},
 		tracks: {type: Array, state: true},
 		display: {type: String, state: true},
+
+		count: {type: Number, state: true}
 	}
 
 	constructor() {
@@ -50,8 +52,10 @@ export default class R4PageChannelTracks extends BaseChannel {
 		urlUtils.updateSearchParams(q, ['table', 'select'])
 		const filtersWithDefaults = [...(q.filters || []), ...this.defaultFilters]
 		q.filters = filtersWithDefaults
-		this.tracks = (await query(q)).data
-		this.lastQuery = q
+		const res = await query(q)
+		this.tracks = res.data
+		this.lastQuery = res.data
+		this.count = res.count
 	}
 
 	setDisplay(event) {
@@ -91,6 +95,7 @@ export default class R4PageChannelTracks extends BaseChannel {
 				<summary>Query tracks</summary>
 				<r4-supabase-query
 					table="channel_tracks"
+					count=${this.count}
 					page=${params.get('page') || 1}
 					limit=${params.get('limit') || 10}
 					order-by=${params.get('order-by') || 'created_at'}

--- a/src/pages/r4-page-channel-tracks.js
+++ b/src/pages/r4-page-channel-tracks.js
@@ -9,17 +9,10 @@ if (!window.r4sdk) window.r4sdk = sdk
 
 export default class R4PageChannelTracks extends BaseChannel {
 	static properties = {
-		/* route props */
-		store: {type: Object, state: true},
-		params: {type: Object, state: true},
-		searchParams: {type: Object, state: true},
-		config: {type: Object, state: true},
-		/* state */
-		channel: {type: Object, reflect: true, state: true},
 		tracks: {type: Array, state: true},
 		display: {type: String, state: true},
-
 		count: {type: Number, state: true}
+		// + props from BaseChannel
 	}
 
 	constructor() {
@@ -53,9 +46,9 @@ export default class R4PageChannelTracks extends BaseChannel {
 		const filtersWithDefaults = [...(q.filters || []), ...this.defaultFilters]
 		q.filters = filtersWithDefaults
 		const res = await query(q)
+		this.count = res.count
 		this.tracks = res.data
 		this.lastQuery = res.data
-		this.count = res.count
 	}
 
 	setDisplay(event) {

--- a/src/pages/r4-page-explore.js
+++ b/src/pages/r4-page-explore.js
@@ -9,6 +9,7 @@ export default class R4PageExplore extends LitElement {
 		config: {type: Object},
 		searchParams: {type: Object, state: true},
 		channels: {type: Array, state: true},
+		count: {type: Number}
 	}
 
 	get channelOrigin() {
@@ -17,8 +18,10 @@ export default class R4PageExplore extends LitElement {
 
 	async onQuery(event) {
 		const q = event.detail
-		this.channels = (await query(q)).data
 		urlUtils.updateSearchParams(q, ['table', 'select'])
+		const res = await query(q)
+		this.count = res.count
+		this.channels = res.data
 		this.lastQuery = q
 	}
 
@@ -36,6 +39,7 @@ export default class R4PageExplore extends LitElement {
 					table="channels"
 					page=${this.searchParams.get('page')}
 					limit=${this.searchParams.get('limit')}
+					count=${this.count}
 					order-by=${this.searchParams.get('order-by')}
 					order-config=${this.searchParams.get('order-config')}
 					filters=${this.searchParams.get('filters')}


### PR DESCRIPTION
We can make a nicer UI for pagination and filters when we count the total amount of rows on a query, ignoring the `limit`.

- Query the `count` from postgresql
- Catch it in parent as `count`
- Pass it back down to r4-supabase-query 
- Create a new getter for `totalPages`

Downside of this is now we have to repeat adding `count` as property to explore page and whereever else we use the query component. Maybe ok?

Another downside is that as soon as r4-supabase-query receives a `count` prop, it re-renders and queries a second time. This could be solved if we fetch the query count directly in the component. This way we also don't have to pass it up and down..