### PR TITLE
Loop through all example files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist-lib
 !.vscode/extensions.json
 .idea
 .DS_Store
+TAGS

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-plugin-lit": "^1.8.3",
         "eslint-plugin-wc": "^1.5.0",
         "prettier": "^2.8.8",
+        "recursive-readdir": "^2.2.3",
         "vite": "^4.3.9"
       }
     },
@@ -2065,6 +2066,18 @@
         "quickselect": "^2.0.0"
       }
     },
+    "node_modules/recursive-readdir": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -4004,6 +4017,15 @@
       "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
       "requires": {
         "quickselect": "^2.0.0"
+      }
+    },
+    "recursive-readdir": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.5"
       }
     },
     "requireindex": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-lit": "^1.8.3",
     "eslint-plugin-wc": "^1.5.0",
     "prettier": "^2.8.8",
+    "recursive-readdir": "^2.2.3",
     "vite": "^4.3.9"
   },
   "repository": {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
-import {resolve} from 'path'
+import {resolve, join} from 'path'
 import {defineConfig} from 'vite'
+import recursive from 'recursive-readdir'
 
 /* treat the path '/examples/r4-app.html/' as SPA (serve the file, let js handle URL route) */
 const vitePluginR4AppSPA = (options) => ({
@@ -16,6 +17,24 @@ const vitePluginR4AppSPA = (options) => ({
 	},
 })
 
+const generateExampleInputFiles = async () => {
+	const entriesDir = resolve('./examples/')
+	const entries = await recursive(entriesDir)
+	const inputFiles = entries
+		.filter((entry) => {
+			return entry.endsWith('.html')
+		})
+		.reduce((acc, entry) => {
+			const key = entry.replace(/\//g, '_')
+			const inputFilePath = entry.replace(__dirname + '/', '')
+			const inputName = inputFilePath.replace('.html', '').split('/').join('_')
+			acc[inputName] = `./${inputFilePath}`
+			return acc
+		}, {})
+	console.log(inputFiles)
+	return inputFiles
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
 	plugins: [vitePluginR4AppSPA()],
@@ -25,51 +44,7 @@ export default defineConfig({
 		rollupOptions: {
 			input: {
 				main: resolve('index.html'),
-				examples: resolve('examples/index.html'),
-				r4Actions: resolve('examples/r4-actions/index.html'),
-				r4App: resolve('examples/r4-app/index.html'),
-				r4Appearance: resolve('examples/r4-color-scheme/index.html'),
-				r4Avatar: resolve('examples/r4-avatar/index.html'),
-				r4AvatarUpload: resolve('examples/r4-avatar-upload/index.html'),
-				r4AvatarUpdate: resolve('examples/r4-avatar-update/index.html'),
-				r4AuthStatus: resolve('examples/r4-auth-status/index.html'),
-				r4Channel: resolve('examples/r4-channel/index.html'),
-				r4ChannelCard: resolve('examples/r4-channel-card/index.html'),
-				r4ChannelActions: resolve('examples/r4-channel-actions/index.html'),
-				r4ChannelCreate: resolve('examples/r4-channel-create/index.html'),
-				r4ChannelDelete: resolve('examples/r4-channel-delete/index.html'),
-				r4ChannelSharer: resolve('examples/r4-channel-sharer/index.html'),
-				r4ChannelUpdate: resolve('examples/r4-channel-update/index.html'),
-				r4ChannelFollowers: resolve('examples/r4-channel-followers/index.html'),
-				r4ChannelFollowings: resolve('examples/r4-channel-followings/index.html'),
-				r4Channels: resolve('examples/r4-channels/index.html'),
-				r4Dialog: resolve('examples/r4-dialog/index.html'),
-				r4Favicon: resolve('examples/r4-favicon/index.html'),
-				r4Layout: resolve('examples/r4-layout/index.html'),
-				r4List: resolve('examples/r4-list/index.html'),
-				r4Map: resolve('examples/r4-map/index.html'),
-				r4MapPosition: resolve('examples/r4-map-position/index.html'),
-				r4Player: resolve('examples/r4-player/index.html'),
-				r4ButtonPlay: resolve('examples/r4-button-play/index.html'),
-				r4ResetPassword: resolve('examples/r4-reset-password/index.html'),
-				r4Router: resolve('examples/r4-router/index.html'),
-				r4SupabaseQuery: resolve('examples/r4-supabase-query/index.html'),
-				r4SupabaseFilters: resolve('examples/r4-supabase-filters/index.html'),
-				r4ChannelSearch: resolve('examples/r4-channel-search/index.html'),
-				r4TrackSearch: resolve('examples/r4-track-search/index.html'),
-				r4SignIn: resolve('examples/r4-sign-in/index.html'),
-				r4SignOut: resolve('examples/r4-sign-out/index.html'),
-				r4SignUp: resolve('examples/r4-sign-up/index.html'),
-				r4Title: resolve('examples/r4-title/index.html'),
-				r4Track: resolve('examples/r4-track/index.html'),
-				r4TrackActions: resolve('examples/r4-track-actions/index.html'),
-				r4TrackCreate: resolve('examples/r4-track-create/index.html'),
-				r4TrackDelete: resolve('examples/r4-track-delete/index.html'),
-				r4TrackUpdate: resolve('examples/r4-track-update/index.html'),
-				r4Tracks: resolve('examples/r4-tracks/index.html'),
-				r4Tuner: resolve('examples/r4-tuner/index.html'),
-				r4User: resolve('examples/r4-user/index.html'),
-				r4UserChannelsSelect: resolve('examples/r4-user-channels-select/index.html'),
+				...generateExampleInputFiles(),
 			},
 		},
 	},

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import {resolve, join} from 'path'
+import {resolve} from 'path'
 import {defineConfig} from 'vite'
 import recursive from 'recursive-readdir'
 
@@ -21,19 +21,17 @@ const generateExampleInputFiles = async () => {
 	const entriesDir = resolve('./examples/')
 	const entries = await recursive(entriesDir)
 	const inputFiles = entries
-		.filter((entry) => {
-			return entry.endsWith('.html')
-		})
+		.filter((entry) => entry.endsWith('.html'))
 		.reduce((acc, entry) => {
-			const key = entry.replace(/\//g, '_')
 			const inputFilePath = entry.replace(__dirname + '/', '')
 			const inputName = inputFilePath.replace('.html', '').split('/').join('_')
 			acc[inputName] = `./${inputFilePath}`
 			return acc
 		}, {})
-	console.log(inputFiles)
 	return inputFiles
 }
+
+const examples = await generateExampleInputFiles()
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -44,7 +42,7 @@ export default defineConfig({
 		rollupOptions: {
 			input: {
 				main: resolve('index.html'),
-				...generateExampleInputFiles(),
+				...examples,
 			},
 		},
 	},


### PR DESCRIPTION
- not 100% working, not sure why
- should prevent from needing to manually reference all examples html files for the vite build, so it copies these files
- all files in `./examples/**/*.html` should come in
- add dependency for dev, to recursive find dir