### PR TITLE
Update & delete pages and a track menu 

### DIFF
--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -301,6 +301,8 @@ function renderRouterCMS({store, config}) {
 			<r4-route path="/:slug/player" page="channel-player"></r4-route>
 			<r4-route path="/:slug/tracks" page="channel-tracks"></r4-route>
 			<r4-route path="/:slug/tracks/:track_id" page="channel-track"></r4-route>
+			<r4-route path="/:slug/tracks/:track_id/update" page="track-update"></r4-route>
+			<r4-route path="/:slug/tracks/:track_id/delete" page="track-delete"></r4-route>
 			<r4-route path="/:slug/followers" page="channel-followers"></r4-route>
 			<r4-route path="/:slug/following" page="channel-followings"></r4-route>
 		</r4-router>

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -33,7 +33,6 @@ export default class R4App extends LitElement {
 
 		isPlaying: {type: Boolean, attribute: 'is-playing', reflects: true},
 
-
 		/* state for global usage */
 		store: {type: Object, state: true},
 		config: {type: Object, state: true},
@@ -54,8 +53,8 @@ export default class R4App extends LitElement {
 
 	get config() {
 		return {
-			singleChannel: this.singleChannel,
 			href: this.href,
+			singleChannel: this.singleChannel,
 			selectedSlug: this.selectedSlug,
 		}
 	}

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -97,13 +97,13 @@ export default class R4App extends LitElement {
 		this.setTheme()
 
 		if (!this.user) {
-			this.userChannels = undefined
-			this.followers = undefined
-			this.following = undefined
+			this.userChannels = []
+			this.followers = []
+			this.following = []
 		} else {
 			// Refresh user channels
 			this.userChannels = (await sdk.channels.readUserChannels()).data
-			if (this.userChannels && !this.selectedSlug) {
+			if (this.userChannels?.length && !this.selectedSlug) {
 				this.selectedSlug = this.userChannels[0].slug
 			}
 
@@ -178,12 +178,18 @@ export default class R4App extends LitElement {
 				<menu>
 					<a href=${href + '/'}><r4-title small></r4-title></a>
 					<a href=${href + '/explore'}>Explore</a>
-					${!user ? html`<a href=${href + '/sign/up'}>Create radio</a>` : ''}
-					${!user ? html`<a href=${href + '/sign/in'}>My radio</a>` : ''}
-					${this.userChannels?.length
-						? html`<a href=${href + '/' + this.selectedSlug}>@${this.selectedChannel.slug}</a>`
-						: ''}
-					${this.userChannels?.length ? html`<a href=${href + '/settings'}>Settings</a>` : ''}
+
+					${!user
+						? html`
+								${!user ? html`<a href=${href + '/sign/up'}>Create radio</a>` : ''}
+								${!user ? html`<a href=${href + '/sign/in'}>My radio</a>` : ''}
+						  `
+						: html`
+								${this.selectedChannel
+									? html`<a href=${href + '/' + this.selectedSlug}>@${this.selectedChannel.slug}</a>`
+									: html`<a href=${href + '/new'}>Create radio</a>`}
+								${this.userChannels?.length ? html`<a href=${href + '/settings'}>Settings</a>` : ''}
+						  `}
 				</menu>
 			</header>
 		`

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -210,8 +210,9 @@ export default class R4App extends LitElement {
 
 		this.isPlaying = true
 
-		if (!tracks && channel?.slug) {
-			const {data: channelTracks} = await sdk.channels.readChannelTracks(channel.slug)
+		const slug = channel?.slug || track.slug
+		if (!tracks && slug) {
+			const {data: channelTracks} = await sdk.channels.readChannelTracks(slug)
 			tracks = channelTracks.reverse()
 		}
 

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -297,6 +297,7 @@ function renderRouterCMS({store, config}) {
 			<r4-route path="/:slug" page="channel"></r4-route>
 			<r4-route path="/:slug/feed" page="channel-feed"></r4-route>
 			<r4-route path="/:slug/update" page="channel-update"></r4-route>
+			<r4-route path="/:slug/delete" page="channel-delete"></r4-route>
 			<r4-route path="/:slug/player" page="channel-player"></r4-route>
 			<r4-route path="/:slug/tracks" page="channel-tracks"></r4-route>
 			<r4-route path="/:slug/tracks/:track_id" page="channel-track"></r4-route>

--- a/src/components/r4-channel-actions.js
+++ b/src/components/r4-channel-actions.js
@@ -1,4 +1,4 @@
-import { sdk } from '@radio4000/sdk'
+import {sdk} from '@radio4000/sdk'
 
 const template = document.createElement('template')
 template.innerHTML = `
@@ -85,7 +85,7 @@ export default class R4ChannelActions extends HTMLElement {
 		}
 	}
 
-	renderAsyncOption({ value, text }) {
+	renderAsyncOption({value, text}) {
 		const $actions = this.querySelector('r4-actions select')
 
 		const $asyncOption = document.createElement('option')

--- a/src/components/r4-channel-create.js
+++ b/src/components/r4-channel-create.js
@@ -15,7 +15,6 @@ fieldsTemplate.innerHTML = `
 	</slot>
 `
 
-
 export default class R4ChannelCreate extends R4Form {
 	submitText = 'Create channel'
 	constructor() {
@@ -24,7 +23,7 @@ export default class R4ChannelCreate extends R4Form {
 	}
 
 	errors = {
-		'default': {
+		default: {
 			message: 'Unhandled error',
 		},
 		'slug-exists-firebase': {
@@ -58,7 +57,7 @@ export default class R4ChannelCreate extends R4Form {
 		try {
 			const {data: user} = await sdk.users.readUser()
 			if (!user) {
-				throw { code: 'sign-in' }
+				throw {code: 'sign-in'}
 			}
 			res = await sdk.channels.createChannel({
 				name: channel.name,
@@ -73,7 +72,7 @@ export default class R4ChannelCreate extends R4Form {
 		}
 		this.enableForm()
 
-		const { data } = res
+		const {data} = res
 		if (data) {
 			this.resetForm()
 		}

--- a/src/components/r4-form.js
+++ b/src/components/r4-form.js
@@ -184,6 +184,7 @@ export default class R4Form extends HTMLElement {
 				}
 
 				if (fieldName === 'submit') {
+					$field.setAttribute('role', 'primary')
 					$field.innerText = this.submitText
 				}
 

--- a/src/components/r4-track-actions.js
+++ b/src/components/r4-track-actions.js
@@ -9,17 +9,6 @@ template.innerHTML = `
 `
 
 export default class R4TrackActions extends HTMLElement {
-	get id() {
-		return this.getAttribute('id')
-	}
-	set id(str) {
-		if (str) {
-			this.setAttribute('id', str)
-		} else {
-			this.removeAttribute('id')
-		}
-	}
-
 	constructor() {
 		super()
 		/* keydown to fix "space" as key to open the select */
@@ -35,43 +24,53 @@ export default class R4TrackActions extends HTMLElement {
 	 lazy load some options */
 	async onPush(event) {
 		/* fix select accessibility */
-		if (event.type === 'keydown') {
-			if (event.keyCode !== 32) {
-				return
-			}
+		if (event.type === 'keydown' && event.keyCode !== 32) return
+
+		// without an id we can't do anything
+		if (!this.id) return
+
+		/* if can't edit, try checking if can */
+		if (!this.canEdit) {
+			this.canEdit = await sdk.tracks.canEditTrack(this.id)
 		}
 
+		if (this.didRenderAsync) return
+
+		console.log(this.id, this.canEdit)
+
+		/* if can edit, render option for editors */
+		if (this.canEdit) {
+			this.renderAsyncOption({
+				value: 'update',
+				text: 'Update',
+			})
+			this.renderAsyncOption({
+				value: 'delete',
+				text: 'Delete',
+			})
+			this.didRenderAsync = true
+		}
+
+		// if no track yet, fetch it
 		if (this.id && !this.track) {
-			const { error, data } = await sdk.tracks.readTrack(this.id)
+			const {error, data} = await sdk.tracks.readTrack(this.id)
 			if (error) {
-				this.renderAsyncOptions({
+				this.renderAsyncOption({
 					value: 'track',
-					text: `track id: track error`
+					text: `track id: track error`,
 				})
 			} else if (data && !this.canEdit) {
-				this.track = data
 				this.canEdit = await sdk.tracks.canEditTrack(this.id)
-				if (this.canEdit) {
-					this.renderAsyncOptions({
-						value: 'update',
-						text: `Update`
-					})
-					this.renderAsyncOptions({
-						value: 'delete',
-						text: `Delete`
-					})
-				}
+				this.track = data
 			}
 		}
 	}
 
-	renderAsyncOptions({value, text}) {
+	renderAsyncOption({value, text}) {
 		const $actions = this.querySelector('r4-actions select')
-
 		const $asyncOption = document.createElement('option')
 		$asyncOption.value = value
 		$asyncOption.innerText = text
-
 		$actions.append($asyncOption)
 	}
 }

--- a/src/components/r4-track-actions.js
+++ b/src/components/r4-track-actions.js
@@ -4,9 +4,9 @@ template.innerHTML = `
 	<r4-actions>
 		<option value="">...</option>
 		<option value="play">Play</option>
-		<option value="share">Share</option>
 	</r4-actions>
 `
+// <option value="share">Share</option>
 
 export default class R4TrackActions extends HTMLElement {
 	constructor() {

--- a/src/components/r4-track.js
+++ b/src/components/r4-track.js
@@ -86,6 +86,20 @@ export default class R4Track extends LitElement {
 	onAction({detail}) {
 		if (detail === 'update') page(`/${this.track.slug}/tracks/${this.track.id}/update`)
 		if (detail === 'delete') page(`/${this.track.slug}/tracks/${this.track.id}/delete`)
+		if (detail === 'play') {
+			console.log(this.track.slug)
+			const playEvent = new CustomEvent('r4-play', {
+				bubbles: true,
+				detail: {
+					// channel: // we don't have it here
+					track: this.track
+				},
+			})
+			this.dispatchEvent(playEvent)
+		}
+		// if (['share'].indexOf(detail) > -1) {
+		// 	this.openDialog(detail)
+		// }
 	}
 
 	createRenderRoot() {

--- a/src/components/r4-track.js
+++ b/src/components/r4-track.js
@@ -1,13 +1,14 @@
-import { sdk } from '@radio4000/sdk'
-import { LitElement, html } from 'lit'
+import {sdk} from '@radio4000/sdk'
+import {LitElement, html} from 'lit'
+import page from 'page/page.mjs'
 
 export default class R4Track extends LitElement {
 	static properties = {
-		origin: { type: String },
-		href: { type: String },
-		id: { type: String },
-		track: { type: Object },
-		loading: { type: Boolean, reflect: true, state: true },
+		origin: {type: String},
+		href: {type: String},
+		id: {type: String},
+		track: {type: Object},
+		loading: {type: Boolean, reflect: true, state: true},
 	}
 
 	/* if the attribute changed, re-render */
@@ -40,7 +41,7 @@ export default class R4Track extends LitElement {
 		if (res.data) {
 			return res.data
 		} else {
-			return { title: 'No data for this track' }
+			return {title: 'No data for this track'}
 		}
 	}
 
@@ -48,15 +49,20 @@ export default class R4Track extends LitElement {
 		return this.track ? this.renderTrack() : this.renderNoTrack()
 	}
 
+	get url() {
+		return this.origin + this.track.id
+	}
+
 	renderTrack() {
 		const t = this.track
 		return html`
-			<a href=${this.origin + t.id}><r4-track-title>${t.title || t.id}</r4-track-title></a>
+			<a href=${this.url}><r4-track-title>${t.title || t.id}</r4-track-title></a>
 			<r4-track-description>${t.description}</r4-track-description>
 			${t.discogs_url &&
 			html`<r4-track-discogs-url><a href="${t.discogs_url}">View on Discogs</a></r4-track-discogs-url>`}
 			<r4-track-tags>${t.tags.map((tag) => this.renderTag(tag))}</r4-track-tags>
-			<r4-track-mentions>${t.mentions.map(m => this.renderMention(m))}</r4-track-mentions>
+			<r4-track-mentions>${t.mentions.map((m) => this.renderMention(m))}</r4-track-mentions>
+			<r4-track-actions id=${t.id} .canEdit=${this.canEdit} @input=${this.onAction}></r4-track-actions>
 		`
 	}
 
@@ -75,6 +81,11 @@ export default class R4Track extends LitElement {
 		if (!slug) return null
 		const url = `${this.href}/${slug}`
 		return html`<a href="${url}" label>${slug}</a>`
+	}
+
+	onAction({detail}) {
+		if (detail === 'update') page(`${this.url}/update`)
+		if (detail === 'delete') page(`${this.url}/delete`)
 	}
 
 	createRenderRoot() {

--- a/src/components/r4-track.js
+++ b/src/components/r4-track.js
@@ -84,8 +84,8 @@ export default class R4Track extends LitElement {
 	}
 
 	onAction({detail}) {
-		if (detail === 'update') page(`${this.url}/update`)
-		if (detail === 'delete') page(`${this.url}/delete`)
+		if (detail === 'update') page(`/${this.track.slug}/tracks/${this.track.id}/update`)
+		if (detail === 'delete') page(`/${this.track.slug}/tracks/${this.track.id}/delete`)
 	}
 
 	createRenderRoot() {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import R4PageAdd from './r4-page-add.js'
 import R4PageChannel from './r4-page-channel.js'
 import R4PageChannelUpdate from './r4-page-channel-update.js'
+import R4PageChannelDelete from './r4-page-channel-delete.js'
 import R4PageChannelFeed from './r4-page-channel-feed.js'
 import R4PageChannelPlayer from './r4-page-channel-player.js'
 import R4PageChannelFollowings from './r4-page-channel-followings.js'
@@ -26,6 +27,7 @@ customElements.define('r4-page-add', R4PageAdd)
 customElements.define('r4-page-settings', R4PageSettings)
 customElements.define('r4-page-channel', R4PageChannel)
 customElements.define('r4-page-channel-update', R4PageChannelUpdate)
+customElements.define('r4-page-channel-delete', R4PageChannelDelete)
 customElements.define('r4-page-channel-feed', R4PageChannelFeed)
 customElements.define('r4-page-channel-player', R4PageChannelPlayer)
 customElements.define('r4-page-channel-track', R4PageChannelTrack)
@@ -38,6 +40,7 @@ export default {
 	R4PageAdd,
 	R4PageChannel,
 	R4PageChannelUpdate,
+	R4PageChannelDelete,
 	R4PageChannelFeed,
 	R4PageChannelPlayer,
 	R4PageExplore,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,6 +14,8 @@ import R4PageNew from './r4-page-new.js'
 import R4PageSettings from './r4-page-settings'
 import R4PageSign from './r4-page-sign.js'
 import R4PageChannelTrack from './r4-page-channel-track'
+import R4PageTrackUpdate from './r4-page-track-update.js'
+import R4PageTrackDelete from './r4-page-track-delete.js'
 import R4PageChannelTracks from './r4-page-channel-tracks'
 import R4PagePlayground from './r4-page-playground.js'
 
@@ -35,6 +37,8 @@ customElements.define('r4-page-channel-tracks', R4PageChannelTracks)
 customElements.define('r4-page-channel-followings', R4PageChannelFollowings)
 customElements.define('r4-page-channel-followers', R4PageChannelFollowers)
 customElements.define('r4-page-playground', R4PagePlayground)
+customElements.define('r4-page-track-update', R4PageTrackUpdate)
+customElements.define('r4-page-track-delete', R4PageTrackDelete)
 
 export default {
 	R4PageAdd,
@@ -51,6 +55,8 @@ export default {
 	R4PageSettings,
 	R4PageSign,
 	R4PageChannelTrack,
+	R4PageTrackUpdate,
+	R4PageTrackDelete,
 	R4PageChannelTracks,
 	R4PageChannelFollowings,
 	R4PageChannelFollowers,

--- a/src/pages/r4-page-add.js
+++ b/src/pages/r4-page-add.js
@@ -72,7 +72,6 @@ export default class R4PageAdd extends BaseChannel {
 					>
 					<nav-item><code>></code> <a href=${link + '/tracks'}>Tracks</a></nav-item>
 					<nav-item>Add</nav-item>
-					<nav-item><a href=${link + '/update'}>Update</a></nav-item>
 				</nav>
 				<h1>Add track</h1>
 			</header>

--- a/src/pages/r4-page-channel-delete.js
+++ b/src/pages/r4-page-channel-delete.js
@@ -16,12 +16,12 @@ export default class R4PageChannelDelete extends BaseChannel {
 			</nav>
 			<main>
 				<h1>Delete channel</h1>
-				${channel ? html`<r4-channel-delete id=${channel.id} @submit=${this.onChannelDelete}></r4-channel-delete>` : ''}
+				${channel ? html`<r4-channel-delete id=${channel.id} @submit=${this.onDelete}></r4-channel-delete>` : ''}
 			</main>
 		`
 	}
 
-	async onChannelDelete({detail}) {
+	async onDelete({detail}) {
 		/* no error? we deleted */
 		if (!detail.data) {
 			page('/')

--- a/src/pages/r4-page-channel-delete.js
+++ b/src/pages/r4-page-channel-delete.js
@@ -1,0 +1,34 @@
+import {html} from 'lit'
+import page from 'page/page.mjs'
+import BaseChannel from './base-channel'
+
+export default class R4PageChannelDelete extends BaseChannel {
+	render() {
+		const link = this.channelOrigin
+		const channel = this.store.userChannels.find((channel) => {
+			return channel.id === this.channel?.id
+		})
+		return html`
+			<nav>
+				<nav-item> <code>@</code><a href=${link}>${this.params.slug}</a> </nav-item>
+				${this.canEdit ? html`<nav-item><a href=${link + '/update'}>Update</a></nav-item>` : ''}
+				${this.canEdit ? html`<nav-item>Delete</nav-item>` : ''}
+			</nav>
+			<main>
+				<h1>Delete channel</h1>
+				${channel ? html`<r4-channel-delete id=${channel.id} @submit=${this.onChannelDelete}></r4-channel-delete>` : ''}
+			</main>
+		`
+	}
+
+	async onChannelDelete({detail}) {
+		/* no error? we deleted */
+		if (!detail.data) {
+			page('/')
+		}
+	}
+
+	createRenderRoot() {
+		return this
+	}
+}

--- a/src/pages/r4-page-channel-track.js
+++ b/src/pages/r4-page-channel-track.js
@@ -1,16 +1,16 @@
-import { html  } from 'lit'
-import { until } from 'lit/directives/until.js'
-import { sdk } from '@radio4000/sdk'
+import {html} from 'lit'
+import {until} from 'lit/directives/until.js'
+import {sdk} from '@radio4000/sdk'
 import page from 'page/page.mjs'
 import BaseChannel from './base-channel'
 
 export default class R4PageChannelTrack extends BaseChannel {
 	static properties = {
-		store: { type: Object, state: true },
-		params: { type: Object, state: true },
-		config: { type: Object, state: true },
+		store: {type: Object, state: true},
+		params: {type: Object, state: true},
+		config: {type: Object, state: true},
 
-		track: { type: Object, reflect: true, state: true },
+		track: {type: Object, reflect: true, state: true},
 	}
 
 	firstUpdated() {
@@ -19,7 +19,7 @@ export default class R4PageChannelTrack extends BaseChannel {
 
 	/* find data, the current channel id we want to add to */
 	async findTrack() {
-		const { data } = await sdk.tracks.readTrack(this.params.track_id)
+		const {data} = await sdk.tracks.readTrack(this.params.track_id)
 		if (data && data.id) {
 			return data
 		}
@@ -40,13 +40,10 @@ export default class R4PageChannelTrack extends BaseChannel {
 		return html`
 			<nav>
 				<nav-item>
-					<code>@</code>
-					<a href=${this.channelOrigin}>${channel.slug}</a>
-					<code>/</code>
-					<a href=${this.channelOrigin + '/tracks'}>tracks</a>
-					<code>/</code>
-					<a href=${this.channelOrigin + '/tracks' + '/' + track_id}>
-						${track_id}
+					<code>@</code> <a href=${this.channelOrigin}>${channel.slug}</a>
+					<code>/</code> <a href=${this.channelOrigin + '/tracks'}>tracks</a>
+					<code>/</code> <a href=${this.channelOrigin + '/tracks' + '/' + track_id}>
+					${track_id}
 					</a>
 				</nav-item>
 				<nav-item>

--- a/src/pages/r4-page-channel-track.js
+++ b/src/pages/r4-page-channel-track.js
@@ -102,7 +102,7 @@ export default class R4PageChannelTrack extends BaseChannel {
 		return html`<span>Loading track...</span>`
 	}
 
-	async onTrackAction({ detail }) {
+	async onTrackAction({detail}) {
 		if (detail) {
 			if (detail === 'play') {
 				const track = await this.track
@@ -127,13 +127,13 @@ export default class R4PageChannelTrack extends BaseChannel {
 		page(`/${this.params.slug}/tracks`)
 	}
 
-	async onTrackUpdate({ detail }) {
+	async onTrackUpdate({detail}) {
 		if (!detail.error && detail.data) {
 			this.closeDialog('update')
 		}
 	}
 
-	onDialogClose({ target }) {
+	onDialogClose({target}) {
 		const name = target.getAttribute('name')
 		if (name === 'track') {
 			if (this.config.singleChannel) {

--- a/src/pages/r4-page-channel-tracks.js
+++ b/src/pages/r4-page-channel-tracks.js
@@ -68,7 +68,6 @@ export default class R4PageChannelTracks extends BaseChannel {
 					<nav-item><code>@</code><a href=${link}>${this.params.slug}</a></nav-item>
 					<nav-item> <code>></code> Tracks </nav-item>
 					${this.canEdit ? html`<nav-item><a href=${this.config.href + '/add'}>Add</a></nav-item>` : ''}
-					${this.canEdit ? html`<nav-item><a href=${link + '/update'}>Update</a></nav-item>` : ''}
 				</nav>
 				${this.channel ? html`<h1>${this.channel.name} tracks</h1>` : ''}
 			</header>

--- a/src/pages/r4-page-channel-update.js
+++ b/src/pages/r4-page-channel-update.js
@@ -5,17 +5,8 @@ import BaseChannel from './base-channel'
 
 export default class R4PageChannelUpdate extends BaseChannel {
 	render() {
-		const {channel} = this
-		const link = this.channelOrigin
-
-		// if (channel === null) return html`<p>404 - There is no channel with this slug.</p>`
-		// if (!channel) return html`<p>Loading...</p>`
-		// if (channel && !this.canEdit) return html`<p>You don't have permissions to edit this channel.</p>`
-
-		const currentUserChannel = this.store.userChannels.find((channel) => {
-			return channel.id === this.channel?.id
-		})
-
+		const {channel, channelOrigin: link} = this
+		if (channel && !this.canEdit) return html`<p>You don't have permissions to edit this channel.</p>`
 		return html`
 			<nav>
 				<nav-item> <code>@</code><a href=${link}>${this.params.slug}</a> </nav-item>
@@ -24,41 +15,37 @@ export default class R4PageChannelUpdate extends BaseChannel {
 			</nav>
 			<main>
 				<h1>Update channel settings</h1>
-				${currentUserChannel
+				${channel
 					? html`
 							<r4-channel-update
-								id=${currentUserChannel.id}
-								slug=${currentUserChannel.slug}
-								name=${currentUserChannel.name}
-								description=${currentUserChannel.description}
-								url=${currentUserChannel.url}
-								longitude=${currentUserChannel.longitude}
-								latitude=${currentUserChannel.latitude}
-								@submit=${this.onChannelUpdate}
+								id=${channel.id}
+								slug=${channel.slug}
+								name=${channel.name}
+								description=${channel.description}
+								url=${channel.url}
+								longitude=${channel.longitude}
+								latitude=${channel.latitude}
+								@submit=${this.onUpdate}
 							></r4-channel-update>
+
 							<h2>Avatar</h2>
-							<r4-avatar-update slug=${currentUserChannel.slug}></r4-avatar-update>
+							<r4-avatar-update slug=${channel.slug}></r4-avatar-update>
+
 							<h2>Map</h2>
 							<r4-map-position
 								@submit=${this.onMapSubmit}
-								longitude=${currentUserChannel.longitude}
-								latitude=${currentUserChannel.latitude}
+								longitude=${channel.longitude}
+								latitude=${channel.latitude}
 							></r4-map-position>
-						<p><a href="${this.channelOrigin}/delete">Delete channel</a></p>
+
+							<p><a href="${link}/delete">Delete channel</a></p>
 					  `
 					: ''}
 			</main>
 		`
 	}
 
-	async onChannelDelete({detail}) {
-		/* no error? we deleted */
-		if (!detail.data) {
-			page('/')
-		}
-	}
-
-	async onChannelUpdate({detail}) {
+	async onUpdate({detail}) {
 		const newSlug = detail?.data?.slug
 		if (newSlug && newSlug !== this.params.slug) {
 			page(`/${newSlug}`)
@@ -71,7 +58,6 @@ export default class R4PageChannelUpdate extends BaseChannel {
 	async onMapSubmit({detail}) {
 		const channelId = this.channel.id
 		if (!channelId) return
-
 		try {
 			if (detail) {
 				await sdk.channels.updateChannel(channelId, {

--- a/src/pages/r4-page-channel-update.js
+++ b/src/pages/r4-page-channel-update.js
@@ -1,7 +1,7 @@
 import {html} from 'lit'
 import page from 'page/page.mjs'
-import BaseChannel from './base-channel'
 import {sdk} from '@radio4000/sdk'
+import BaseChannel from './base-channel'
 
 export default class R4PageChannelUpdate extends BaseChannel {
 	render() {
@@ -19,9 +19,8 @@ export default class R4PageChannelUpdate extends BaseChannel {
 		return html`
 			<nav>
 				<nav-item> <code>@</code><a href=${link}>${this.params.slug}</a> </nav-item>
-				<nav-item><code>></code> <a href=${link + '/tracks'}>Tracks</a></nav-item>
-				${this.canEdit ? html`<nav-item><a href=${this.config.href + '/add'}>Add</a></nav-item>` : ''}
 				${this.canEdit ? html`<nav-item>Update</nav-item>` : ''}
+				${this.canEdit ? html`<nav-item><a href=${link + '/delete'}>Delete</a></nav-item>` : ''}
 			</nav>
 			<main>
 				<h1>Update channel settings</h1>
@@ -45,11 +44,7 @@ export default class R4PageChannelUpdate extends BaseChannel {
 								longitude=${currentUserChannel.longitude}
 								latitude=${currentUserChannel.latitude}
 							></r4-map-position>
-							<h2>Danger zone</h2>
-							<details>
-								<summary>Delete channel</summary>
-								<r4-channel-delete id=${currentUserChannel.id} @submit=${this.onChannelDelete}></r4-channel-delete>
-							</details>
+						<p><a href="${this.channelOrigin}/delete">Delete channel</a></p>
 					  `
 					: ''}
 			</main>

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -60,14 +60,11 @@ export default class R4PageChannel extends BaseChannel {
 		return html`
 			<header>
 				<nav>
-					<nav-item>
-						<code>@</code>${this.params.slug}
-						<code>></code>
-					</nav-item>
-					<nav-item>
-						<a href=${link + '/tracks'}>Tracks</a>${this.canEdit
-							? html`, <a href=${this.config.href + '/add'}>Add</a>`
-							: null}${this.canEdit ? html` & <a href=${link + '/update'}>Update</a>` : null}
+					<nav-item><code>@</code>${this.params.slug}</nav-item>
+					<nav-item
+						><code>></code>
+						<a href=${link + '/tracks'}>Tracks</a>
+						${this.canEdit ? html`<a href=${this.config.href + '/add'}>Add</a>` : null}
 					</nav-item>
 				</nav>
 
@@ -149,7 +146,12 @@ export default class R4PageChannel extends BaseChannel {
 					(t) => html`
 						<li>
 							<r4-button-play .channel=${this.channel} .track=${t} .tracks=${this.tracks}></r4-button-play>
-							<r4-track .track=${t} href=${this.config.href} origin=${'' || this.tracksOrigin} .canEdit=${this.canEdit}></r4-track>
+							<r4-track
+								.track=${t}
+								href=${this.config.href}
+								origin=${'' || this.tracksOrigin}
+								.canEdit=${this.canEdit}
+							></r4-track>
 						</li>
 					`
 				)}

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -149,7 +149,7 @@ export default class R4PageChannel extends BaseChannel {
 					(t) => html`
 						<li>
 							<r4-button-play .channel=${this.channel} .track=${t} .tracks=${this.tracks}></r4-button-play>
-							<r4-track .track=${t} href=${this.config.href} origin=${'' || this.tracksOrigin}></r4-track>
+							<r4-track .track=${t} href=${this.config.href} origin=${'' || this.tracksOrigin} .canEdit=${this.canEdit}></r4-track>
 						</li>
 					`
 				)}

--- a/src/pages/r4-page-new.js
+++ b/src/pages/r4-page-new.js
@@ -12,7 +12,7 @@ export default class R4PageNew extends LitElement {
 		if (!this.store.user) {
 			page(`/sign/in`)
 		}
-		if (this.store.userChannels) {
+		if (this.store.userChannels?.length) {
 			page(`/${this.store.userChannels[0].slug}`)
 		}
 	}
@@ -20,7 +20,9 @@ export default class R4PageNew extends LitElement {
 	render() {
 		return html`
 			<main>
+				<h1>Create radio channel</h1>
 				<r4-channel-create @submit=${this.onChannelCreate}></r4-channel-create>
+				<p>The slug is what will be used for the URL of your channel. You can always change it later.</p>
 			</main>
 		`
 	}

--- a/src/pages/r4-page-track-delete.js
+++ b/src/pages/r4-page-track-delete.js
@@ -1,0 +1,51 @@
+import {html} from 'lit'
+import {sdk} from '@radio4000/sdk'
+import page from 'page/page.mjs'
+import BaseChannel from './base-channel'
+
+export default class R4PageTrackDelete extends BaseChannel {
+	async loadTrack() {
+		const {data, error} = await sdk.tracks.readTrack(this.params.track_id)
+		this.track = data
+		this.error = error
+	}
+	render() {
+		if (!this.track) {
+			this.loadTrack()
+		}
+
+		if (this.error) {
+			return html`error: ${this.error.message}`
+		}
+
+		const {track} = this
+		const link = this.channelOrigin
+
+		return html`
+			<nav>
+				<nav-item> <code>@</code><a href=${link}>${this.params.slug}</a> </nav-item>
+				<nav-item><code>></code> <a href=${link + '/tracks'}>Tracks</a></nav-item>
+				<nav-item><code>></code> ${track?.title}</nav-item>
+			</nav>
+			<main>
+				<h1>Delete track</h1>
+				${track
+					? html`
+						<p>Are you sure you want to delete <em>${track?.title}</em>?</p>
+						<r4-track-delete id=${track.id} @submit=${this.onDelete}></r4-channel-delete>`
+					: html`<p>Loading...</p>`}
+			</main>
+		`
+	}
+
+	async onDelete({detail}) {
+		/* no error? we deleted */
+		if (!detail?.data) {
+			page(this.channelOrigin + '/tracks')
+		}
+	}
+
+	createRenderRoot() {
+		return this
+	}
+}

--- a/src/pages/r4-page-track-update.js
+++ b/src/pages/r4-page-track-update.js
@@ -1,0 +1,60 @@
+import {html} from 'lit'
+import {sdk} from '@radio4000/sdk'
+import BaseChannel from './base-channel'
+
+export default class R4PageChannelUpdate extends BaseChannel {
+	async loadTrack() {
+		const {data, error} = await sdk.tracks.readTrack(this.params.track_id)
+		this.track = data
+		this.error = error
+	}
+
+	render() {
+		if (!this.track) {
+			this.loadTrack()
+		}
+
+		if (this.error) {
+			return html`<p>Error: ${this.error.message}</p>`
+		}
+
+		const {track} = this
+		const link = this.channelOrigin
+
+		return html`
+			<nav>
+				<nav-item> <code>@</code><a href=${link}>${this.params.slug}</a> </nav-item>
+				<nav-item><code>></code> <a href=${link + '/tracks'}>Tracks</a></nav-item>
+				<nav-item><code>></code> ${track?.title}</nav-item>
+			</nav>
+			<main>
+				<h1>Update track</h1>
+				${track
+					? html`<r4-track-update
+								id=${track.id}
+								url=${track.url}
+								title=${track.title}
+								discogsUrl=${track.discogsUrl}
+								description=${track.description}
+								@submit=${this.onUpdate}
+							></r4-track-update>
+							<p>
+								<a href=${link + '/tracks/' + track.id + '/delete'}>Delete track</a>
+							</p>
+							<p></p> `
+					: html`<p>Loading...</p>`}
+			</main>
+		`
+	}
+
+	async onUpdate({detail}) {
+		console.log(detail)
+		if (!detail.error) {
+			// all good
+		}
+	}
+
+	createRenderRoot() {
+		return this
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noEmit": true,
 
     /* Linting */
+		"checkJs": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,25 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "skipLibCheck": true,
+	"compilerOptions": {
+		"target": "ES2020",
+		"useDefineForClassFields": true,
+		"module": "ESNext",
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"skipLibCheck": true,
 		"allowJs": true,
 
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
 
-    /* Linting */
+		/* Linting */
 		"checkJs": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
-  },
-  "include": ["./src/"]
+		"strict": false,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["./src/"]
 }


### PR DESCRIPTION
## New

- Adds new /update and /delete pages for channel and track so you can link these actions.
- Add `<r4-track-actions` back into r4-track so you can quickly go to delete/update. This could become a modal later on the channel + tracks pages, where we have list of tracks.

## Notes

- [X] Play track actions isn't working
- [ ] Share track actions isn't working