### PR TITLE
Fix theme urls

### DIFF
--- a/examples/r4-app/index.html
+++ b/examples/r4-app/index.html
@@ -25,6 +25,8 @@
 			const channel = params.get('channel')
 			const singleChannel = params.get('single-channel')
 
+			//$app.setAttribute('cdn', true)
+			//$app.setAttribute('cdn', 'https://jsdelivr.net/npm/@radio4000/components')
 			$app.setAttribute('href', window.location.origin + '/examples/r4-app/')
 			channel && $app.setAttribute('channel', channel)
 			singleChannel && $app.setAttribute('single-channel', true)

--- a/public/themes/classic.css
+++ b/public/themes/classic.css
@@ -2,7 +2,7 @@
  * A theme resembling classic R4
  */
 
-@import url('/themes/default-extended.css');
+@import url('./default-extended.css');
 
 /* Shared between light and dark color schemes */
 r4-app {

--- a/public/themes/jellybeans.css
+++ b/public/themes/jellybeans.css
@@ -4,7 +4,7 @@
  */
 
 /* Build on top of default theme */
-@import url('/themes/default-extended.css');
+@import url('./default-extended.css');
 
 r4-app {
 	--font: system-ui, sans-serif;

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -14,7 +14,7 @@ export default class R4App extends LitElement {
 	static properties = {
 		// public
 		singleChannel: {type: Boolean, reflect: true, attribute: 'single-channel'},
-		themesURL: {type: String, attribute: 'themes-url', reflect: true},
+		cdn: {type: String, reflect: true},
 		// the channel slug
 		selectedSlug: {type: String, reflect: true, attribute: 'channel'},
 		href: {
@@ -48,10 +48,6 @@ export default class R4App extends LitElement {
 		config: {type: Object, state: true},
 	}
 
-	getThemesURL() {
-		return this.themesURL || 'https://cdn.jsdelivr.net/gh'
-	}
-
 	// This gets passed to all r4-pages.
 	get store() {
 		return {
@@ -79,6 +75,17 @@ export default class R4App extends LitElement {
 	get selectedChannel() {
 		if (!this.userChannels || !this.selectedSlug || !this.user) return null
 		return this.userChannels.find((c) => c.slug === this.selectedSlug)
+	}
+
+	get themeHref() {
+		const file = `${this.theme}.css`
+		if (this.cdn?.length > 4) {
+			return `${this.cdn}/dist/themes/${file}`
+		} else if (this.cdn) {
+			return `https://cdn.jsdelivr.net/npm/@radio4000/components/dist/themes/${file}`
+		} else {
+			return `/themes/${file}`
+		}
 	}
 
 	constructor() {
@@ -198,7 +205,7 @@ export default class R4App extends LitElement {
 					@trackchanged=${this.onTrackChange}
 				></r4-player>
 			</r4-layout>
-			<link rel="stylesheet" href=${`/themes/${this.theme}.css`} />
+			<link rel="stylesheet" href=${this.themeHref} />
 		`
 	}
 


### PR DESCRIPTION
We can't load themes via './themes/x.css' when r4-app is loaded from a CDN script.

This adds a new `cdn` attribute on `<r4-app>`.

- Set it to true to load themes from jsdelivr cdn
- Set it to a url where components are built, like above. Allows to control exactly which version to load

On https://github.com/radio4000/radio4000.github.io/blob/main/index.html we should then be able to just set `cdn` on r4-app and it'll load latest from jsdelivr.

Closes https://github.com/radio4000/components/issues/140