### PR TITLE
Improve query filters

### DIFF
--- a/examples/r4-supabase-filters/index.html
+++ b/examples/r4-supabase-filters/index.html
@@ -56,7 +56,7 @@
 			const $examples = document.querySelectorAll('r4-supabase-filters')
 			$examples.forEach(($example) => {
 				$example.addEventListener('input', (event) => {
-					console.log('filter changed', event.detail)
+					console.log('filter example changed', event.detail)
 				})
 			})
 		</script>

--- a/examples/r4-supabase-query/index.html
+++ b/examples/r4-supabase-query/index.html
@@ -51,8 +51,8 @@
 		</menu>
 
 		<details open>
-			<summary>Universal db query, controls the URL too</summary>
-			<r4-supabase-query id="everything"></r4-supabase-query>
+			<summary>Universal db query</summary>
+			<r4-supabase-query id="everything" table="channels"></r4-supabase-query>
 			<textarea name="everything" readonly></textarea>
 		</details>
 
@@ -66,7 +66,6 @@
 			<textarea name="ko002" readonly></textarea>
 		</details>
 
-
 		<script type="module">
 			import R4SupabaseQuery from '../../src/components/r4-supabase-query.js'
 			import urlUtils from '../../src/libs/url-utils.js'
@@ -77,15 +76,15 @@
 			} = urlUtils
 
 			const $examples = document.querySelectorAll('r4-supabase-query')
-			//const elementProperties = getElementProperties(R4SupabaseQuery)
 
 			const onQuery = function (event) {
-				console.log('query', event.detail)
-				const {target, detail} = event
+				/*
+				console.log('example query', event.detail)
 				const urlSearch = propertiesToSearch(elementProperties, detail)
 				const urlSearchString = `?${urlSearch.toString()}`
 				window.history.replaceState(null, null, urlSearchString)
-				document.querySelector(`textarea[name="${target.id}"]`).innerText = JSON.stringify(detail.data)
+				*/
+				document.querySelector(`textarea[name="${event.target.id}"]`).innerText = JSON.stringify(event.detail)
 			}
 
 			$examples.forEach(($example) => {

--- a/src/components/r4-supabase-filters.js
+++ b/src/components/r4-supabase-filters.js
@@ -21,19 +21,27 @@ export default class R4SupabaseFilters extends LitElement {
 		filters: {type: Array, reflect: true, state: true},
 	}
 
+	// constructor() {
+	// 	super()
+	// 	if (!this.filters) this.filters = []
+	// }
+
 	updated(attr) {
 		/* always update the list when any attribute change
 			 for some attribute, first clear the existing search query */
-		if (attr.get('filters')) this.onFilters()
+		// if (attr.get('filters')) {
+		// 	console.log('filters changeD?')
+		// 	// this.onFilters()
+		// }
 	}
 
 	// When any filter is set or changed
-	async onFilters() {
-		console.log('on filters')
+	async onFilters(updatedFilters) {
+		console.log('onFilters', this.filters, updatedFilters)
 		this.dispatchEvent(
 			new CustomEvent('input', {
 				bubbles: true,
-				detail: this.filters?.filter((filter) => !!filter),
+				detail: updatedFilters?.filter((filter) => !!filter),
 			})
 		)
 	}
@@ -50,19 +58,22 @@ export default class R4SupabaseFilters extends LitElement {
 			column: this.filters?.at(0)?.column || tables[this.table].columns[0],
 			value: '',
 		}
-		const filters = this.filters || []
-		this.filters = [...(filters || []), newFilter]
-	}
-
-	removeFilter(index) {
-		this.filters = this.filters.filter((_, i) => i !== index)
+		console.log('add filter', newFilter)
+		if (!this.filters) this.filters = []
+		this.onFilters([...this.filters, newFilter])
 	}
 
 	updateFilter(index, field, value) {
+		console.log('updateFilter', field, value)
 		/* replace existing filters, including the new one */
 		const newFilters = [...this.filters]
 		newFilters[index][field] = value
-		this.filters = newFilters
+		this.onFilters(newFilters)
+	}
+
+	removeFilter(index) {
+		console.log('removeFilter', index)
+		this.onFilters(this.filters.filter((_, i) => i !== index))
 	}
 
 	createRenderRoot() {

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -64,7 +64,6 @@ export default class R4SupabaseQuery extends LitElement {
 	}
 
 	async onQuery() {
-		console.log('dispatching query')
 		const query = {
 			table: this.table,
 			select: this.select,
@@ -74,6 +73,7 @@ export default class R4SupabaseQuery extends LitElement {
 			page: this.page,
 			limit: this.limit,
 		}
+		console.log('dispatching query', query)
 		this.dispatchEvent(
 			new CustomEvent('query', {
 				bubbles: true,

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -43,7 +43,8 @@ export default class R4SupabaseQuery extends LitElement {
 		// Avoid double-fetch when count is passed back down.
 		if (attr.get('count') === 0) return
 		// Update the list when any attribute changes
-		this.onQuery()
+		// console.log('query component update', attr)
+		// this.onQuery()
 	}
 
 	/* set the correct component initial values, for each table's capacities */
@@ -52,17 +53,18 @@ export default class R4SupabaseQuery extends LitElement {
 		if (!this.limit) this.limit = 10
 		if (!this.table) this.table = tables[0]
 		const tableData = tables[this.table]
-		this.select = this.select || tableData.selects[0]
-		if (tableData.junctions) {
+		this.select = this.select || tableData?.selects[0] || '*'
+		if (tableData?.junctions) {
 			const [foreignTable, foreignColumn] = tableData.junctions[0].split('.')
 			this.orderBy = this.orderBy || foreignColumn
 			this.orderConfig = {...this.orderConfig, foreignTable: foreignTable}
 		} else {
-			this.orderBy = this.orderBy || tableData.columns[0]
+			this.orderBy = this.orderBy || tableData?.columns[0]
 		}
 	}
 
 	async onQuery() {
+		console.log('dispatching query')
 		const query = {
 			table: this.table,
 			select: this.select,
@@ -83,7 +85,10 @@ export default class R4SupabaseQuery extends LitElement {
 	onInput(event) {
 		event.stopPropagation()
 		event.preventDefault()
+
 		const {name, value, valueAsNumber, type: inputType, checked} = event.target
+
+		console.log('onInput', name, value, checked)
 
 		/* handle correctly input type="number" */
 		if (inputType === 'number') {
@@ -102,13 +107,17 @@ export default class R4SupabaseQuery extends LitElement {
 		} else if (name) {
 			this[name] = value
 		}
+		this.onQuery()
 	}
 
 	onFilters(event) {
 		event.preventDefault()
 		event.stopPropagation()
-		const {detail} = event
-		this.filters = detail
+		console.log('caught onFilters. Overwriting filters in r4-supabase-query from r4-supabase-filters', event.detail)
+		if (event.detail) {
+			this.filters = event.detail
+			this.onQuery()
+		}
 	}
 
 	onFormSubmit(event) {
@@ -183,12 +192,12 @@ export default class R4SupabaseQuery extends LitElement {
 					${this.renderQuerySelectByTable()}
 				</select>
 				<input
+					type="text"
 					id="select-display"
 					name="select"
-					@input=${this.onInput}
-					type="text"
-					.value=${this.select}
 					placeholder="postgresql select"
+					.value=${this.select}
+					@input=${this.onInput}
 				/>
 			</fieldset>
 		`
@@ -201,13 +210,13 @@ export default class R4SupabaseQuery extends LitElement {
 				<input
 					id="page"
 					name="page"
-					@input=${this.onInput}
 					type="number"
+					placeholder="page"
 					.value=${this.page}
 					step="1"
 					min="1"
 					max=${this.totalPages}
-					placeholder="page"
+					@input=${this.onInput}
 				/>/${this.totalPages}
 			</fieldset>
 		`
@@ -220,13 +229,13 @@ export default class R4SupabaseQuery extends LitElement {
 				<input
 					id="limit"
 					name="limit"
-					@input=${this.onInput}
 					type="number"
+					placeholder="limit"
 					.value=${this.limit}
 					step="1"
 					min="1"
 					max="4000"
-					placeholder="limit"
+					@input=${this.onInput}
 				/>
 			</fieldset>
 		`

--- a/src/libs/browse.js
+++ b/src/libs/browse.js
@@ -54,6 +54,7 @@ export async function browse({
 	orderConfig = {},
 	filters = [],
 }) {
+	console.log('browse', {table, select, page, limit, orderBy, orderConfig, filters})
 	// We add count exact: to get a .total property back in the response. head:false ensures we still get the rows.
 	let query = supabase.from(table).select(select, {
 		count: 'exact',
@@ -107,8 +108,8 @@ export async function browse({
 
 	// And pagination.
 	const {from, to, limit: l} = getBrowseParams({page, limit})
+	console.log('pagination', {page, limit}, {from, to, limit: l})
 	query = query.range(from, to).limit(l)
-
 	/* console.info('browse.query', query.url.search) */
 
 	return query

--- a/src/libs/url-utils.js
+++ b/src/libs/url-utils.js
@@ -71,6 +71,7 @@ export function propertiesFromSearch(elementProperties) {
  */
 export function updateSearchParams(query, excludeList = []) {
 	const props = R4_QUERY_ATTR.filter((name) => !excludeList.includes(name))
+	console.log('updateSearchParams', query)
 	if (props?.length) {
 		const searchParams = propertiesToSearch(props, query)
 		const searchParamsString = `?${searchParams.toString()}`

--- a/src/pages/base-channels.js
+++ b/src/pages/base-channels.js
@@ -22,10 +22,10 @@ export default class BaseChannels extends R4Page {
 
 	async connectedCallback() {
 		super.connectedCallback()
-		this.queryFromUrl()
+		this.setQueryFromUrl()
 	}
 
-	queryFromUrl() {
+	setQueryFromUrl() {
 		let filters
 		try {
 			filters = JSON.parse(this.searchParams.get('filters'))
@@ -35,10 +35,10 @@ export default class BaseChannels extends R4Page {
 		this.query = {
 			table: 'channels',
 			select: '*',
-			page: this.searchParams.get('page'),
-			limit: this.searchParams.get('limit'),
-			orderBy: this.searchParams.get('orderBy'),
-			orderConfig: this.searchParams.get('orderConfig'),
+			page: this.searchParams.get('page') || 1,
+			limit: this.searchParams.get('limit') || 30,
+			orderBy: this.searchParams.get('orderBy') || 'created_at',
+			orderConfig: this.searchParams.get('orderConfig') || {ascending: false},
 			filters,
 		}
 		console.log('setting query from searchParams', this.query)
@@ -63,21 +63,16 @@ export default class BaseChannels extends R4Page {
 
 	async setChannels() {
 		console.log('setChannels')
-		if (this.query) {
-			const res = await browse(this.query)
-			if (res.error) {
-				console.log('error browsing channels')
-				if (res.error.code === 'PGRST103') {
-					// @todo "range not satisfiable" -> reset pagination
-				}
+		const res = await browse(this.query)
+		if (res.error) {
+			console.log('error browsing channels')
+			if (res.error.code === 'PGRST103') {
+				// @todo "range not satisfiable" -> reset pagination
 			}
-			console.log('setting channels', res)
-			this.count = res.count
-			this.channels = res.data
-		} else {
-			console.log('this happens??')
-			debugger
 		}
+		console.log('setting channels', res)
+		this.count = res.count
+		this.channels = res.data
 	}
 
 	async onQuery(event) {

--- a/src/pages/base-channels.js
+++ b/src/pages/base-channels.js
@@ -6,34 +6,43 @@ import debounce from 'lodash.debounce'
 
 export default class BaseChannels extends R4Page {
 	static properties = {
-		config: {type: Object},
-		searchParams: {type: Object, state: true},
 		channels: {type: Array, state: true},
 		count: {type: Number},
 		query: {type: Object, state: true},
+		// from router
+		config: {type: Object},
+		searchParams: {type: Object, state: true},
 	}
 
 	constructor() {
 		super()
-		this.channels = []
-		/* this.query = {} */
+		// this.channels = []
+		// this.query = {}
 	}
+
 	async connectedCallback() {
 		super.connectedCallback()
+		this.queryFromUrl()
+	}
+
+	queryFromUrl() {
 		let filters
 		try {
 			filters = JSON.parse(this.searchParams.get('filters'))
 		} catch (e) {
 			filters = []
 		}
-
 		this.query = {
+			table: 'channels',
+			select: '*',
 			page: this.searchParams.get('page'),
 			limit: this.searchParams.get('limit'),
 			orderBy: this.searchParams.get('orderBy'),
 			orderConfig: this.searchParams.get('orderConfig'),
 			filters,
 		}
+		console.log('setting query from searchParams', this.query)
+		this.setChannels()
 	}
 
 	get channelOrigin() {
@@ -49,13 +58,25 @@ export default class BaseChannels extends R4Page {
 	setQuery(query) {
 		urlUtils.updateSearchParams({...query}, ['table', 'select'])
 		this.query = {...query}
+		console.log('setQuery', this.query)
 	}
 
 	async setChannels() {
+		console.log('setChannels')
 		if (this.query) {
 			const res = await browse(this.query)
+			if (res.error) {
+				console.log('error browsing channels')
+				if (res.error.code === 'PGRST103') {
+					// @todo "range not satisfiable" -> reset pagination
+				}
+			}
+			console.log('setting channels', res)
 			this.count = res.count
 			this.channels = res.data
+		} else {
+			console.log('this happens??')
+			debugger
 		}
 	}
 
@@ -65,9 +86,10 @@ export default class BaseChannels extends R4Page {
 		await this.setChannels()
 	}
 
-	onFilter(event) {
+	async onSearchFilter(event) {
 		event.preventDefault()
 		const {detail: filter} = event
+		console.log('onSearchFilter', filter)
 		if (filter) {
 			this.setQuery({
 				...this.query,
@@ -79,24 +101,31 @@ export default class BaseChannels extends R4Page {
 				filters: [],
 			})
 		}
-		debounce(this.setChannels, 333)
+		await this.setChannels()
+		// debounce(this.setChannels, 333, {trailing: true})
+	}
+
+	clearFilters() {
+		this.setQuery({...this.query, filters: []})
 	}
 
 	renderHeader() {
 		return [this.renderMenu(), this.renderQuery()]
 	}
+
 	renderQueryFiltersSummary() {
 		const filtersLen = this.query?.filters?.length
 		if (filtersLen) {
-			return html`(<a href=${this.config.href + '/explore'}>clear ${filtersLen}</a>)`
+			return html`<button @click=${this.clearFilters}>clear ${filtersLen}</button>`
 		}
 	}
+
 	renderMenu() {
 		return html`
 			<menu>
 				<li>
 					<r4-supabase-filter-search
-						@input=${this.onFilter}
+						@input=${this.onSearchFilter}
 						.filter=${this.searchFilter}
 						placeholder="channels"
 					></r4-supabase-filter-search>
@@ -105,23 +134,26 @@ export default class BaseChannels extends R4Page {
 			</menu>
 		`
 	}
+
 	renderQuery() {
 		return html`
 			<details>
 				<summary>Filters ${this.renderQueryFiltersSummary()}</summary>
 				<r4-supabase-query
 					table="channels"
+					query=${this.query}
 					page=${this.query?.page}
 					limit=${this.query?.limit}
 					order-by=${this.query?.orderBy}
 					order-config=${this.query?.orderConfig}
 					.filters=${this.query?.filters}
-					@query=${this.onQuery}
 					count=${this.count}
+					@query=${this.onQuery}
 				></r4-supabase-query>
 			</details>
 		`
 	}
+
 	renderMain() {
 		// use this.channels
 		return html``

--- a/src/pages/r4-page-channel-tracks.js
+++ b/src/pages/r4-page-channel-tracks.js
@@ -61,7 +61,7 @@ export default class R4PageChannelTracks extends BaseChannel {
 			page: params.get('page') || 1,
 			limit: params.get('limit') || 10,
 			orderBy: params.get('orderBy') || 'created_at',
-			orderConfig: params.get('orderConfig') || {"ascending":false},
+			orderConfig: params.get('orderConfig') || {ascending:false},
 		}
 		const filters = JSON.parse(params.get('filters'))
 		if (filters) query.filters = filters
@@ -82,7 +82,7 @@ export default class R4PageChannelTracks extends BaseChannel {
 		await this.setTracks()
 	}
 
-	onSearchFilter(event) {
+	async onSearchFilter(event) {
 		event.preventDefault()
 		const {detail: filter} = event
 		console.log('onSearchFilter', filter)
@@ -97,7 +97,8 @@ export default class R4PageChannelTracks extends BaseChannel {
 				filters: [],
 			})
 		}
-		debounce(this.setTracks, 333)
+		await this.setTracks()
+		// debounce(this.setTracks.bind(this), 333)
 	}
 
 	setQuery(query) {

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -14,11 +14,15 @@ export default class R4PageChannel extends BaseChannel {
 		}
 	}
 
+	get defaultFilters() {
+		return [{operator: 'eq', column: 'slug', value: this.channel?.slug}]
+	}
+
 	async setTracks() {
 		const channelTracksQuery = {
 			table: 'channel_tracks',
 			select: '*',
-			filters: [{operator: 'eq', column: 'slug', value: this.channel?.slug}],
+			filters: this.defaultFilters,
 			orderBy: 'created_at',
 			orderConfig: {
 				ascending: false,
@@ -53,6 +57,7 @@ export default class R4PageChannel extends BaseChannel {
 			<r4-supabase-query table="channel_tracks" />
 		`
 	}
+
 	renderTrackItem(track) {
 		return html`
 			<r4-list-item>


### PR DESCRIPTION
- tries to unify querying across /explore, /:slug and /:slug/tracks. Once they are even more unified, we can extract into functions instead of extending all these classes
- fixed some infinite loop issues
- fixed some typos

## questions 

It's not clear to me exactly when we add default filters to the query. If we add it to the query at all, or just add them to the query for `browse()`. Right now they are injected just before we call `browse()`.

If no orderBy + orderConfig is defined, what do we default to? Where is this set exactly?