### PR TITLE
Add currently playing channel to the player

### DIFF
--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -210,7 +210,7 @@ export default class R4App extends LitElement {
 				<r4-player
 					slot="player"
 					${ref(this.playerRef)}
-					?is-playing=${this.isPlaying}
+					.config=${this.config}
 					@trackchange=${this.onTrackChange}
 				></r4-player>
 			</r4-layout>

--- a/src/components/r4-player.js
+++ b/src/components/r4-player.js
@@ -12,8 +12,9 @@ export default class R4Player extends LitElement {
 		image: {type: String},
 		tracks: {type: Array},
 		track: {type: String},
-		isPlaying: {type: Boolean, attribute: 'is-playing', reflect: true},
 		shuffle: {type: Boolean},
+		// The config contains isPlaying, playingChannel, playingTracks, playingTrack
+		config: {type: Object},
 	}
 
 	render() {
@@ -39,8 +40,8 @@ export default class R4Player extends LitElement {
 		if (changedProps.has('tracks') || changedProps.has('track')) {
 			this.play()
 		}
-		if (changedProps.has('isPlaying')) {
-			if (this.isPlaying) {
+		if (changedProps.has('config')) {
+			if (this.config.isPlaying) {
 				this.play()
 			} else {
 				this.pause()
@@ -57,6 +58,7 @@ export default class R4Player extends LitElement {
 				tracks: this.tracks,
 				query: this.query,
 			}
+			this.$player.channelSlug = this.config.playingChannel?.slug
 			this.$player.updatePlaylist(playlist)
 		} else {
 			this.$player.updatePlaylist({tracks: []})
@@ -73,7 +75,7 @@ export default class R4Player extends LitElement {
 	pause() {
 		/* click the radio400-player button */
 		// when in play mode, toggle pause
-		if (this.$playButton.checked === true) {
+		if (this.$playButton?.checked === true) {
 			this.$playButton.click()
 		}
 	}


### PR DESCRIPTION
This fixes the missing/wrong link when you tap the image on <radio4000-player>. 

- The r4-player now gets the whole `config` instead of just `isPlaying`
- `playingChannel.slug` is synced to <radio4000-player> (this fixes the link)

Closes #133 