### PR TITLE
Fix r4-app selectedChannel prop

### DIFF
--- a/examples/r4-app/index.html
+++ b/examples/r4-app/index.html
@@ -23,7 +23,7 @@
 			const $app = document.createElement('r4-app')
 			const params = new URLSearchParams(window.location.search)
 			const channel = params.get('channel')
-			const singleChannel = params.get('single-channel')
+			const singleChannel = params.has('single-channel')
 
 			//$app.setAttribute('cdn', true)
 			//$app.setAttribute('cdn', 'https://jsdelivr.net/npm/@radio4000/components')
@@ -31,6 +31,8 @@
 			channel && $app.setAttribute('channel', channel)
 			singleChannel && $app.setAttribute('single-channel', true)
 			/* !import.meta.env.PROD && $app.setAttribute('themes-url', 'http://localhost:4001') */
+
+			console.log({channel, singleChannel})
 			document.querySelector('body').append($app)
 		</script>
 	</body>

--- a/src/components/r4-app.js
+++ b/src/components/r4-app.js
@@ -149,7 +149,7 @@ export default class R4App extends LitElement {
 		this.refreshUserData.running = true
 
 		if (!this.user) {
-			this.selectedSlug = null
+			if (!this.singleChannel) this.selectedSlug = null
 			this.userChannels = []
 			this.followers = []
 			this.following = []

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -1,7 +1,6 @@
-import {html, LitElement} from 'lit'
+import {html} from 'lit'
 import {sdk} from '@radio4000/sdk'
 import R4Page from '../components/r4-page.js'
-import urlUtils from '../libs/url-utils.js'
 
 // Base class to extend from
 export default class BaseChannel extends R4Page {
@@ -18,13 +17,6 @@ export default class BaseChannel extends R4Page {
 		store: {type: Object, state: true},
 		config: {type: Object, state: true},
 		searchParams: {type: Object, state: true},
-	}
-
-	async willUpdate(changedProperties) {
-		if (changedProperties.has('params')) {
-			console.log('fetching channel because params changed')
-			// await this.setChannel()
-		}
 	}
 
 	async connectedCallback() {
@@ -80,7 +72,7 @@ export default class BaseChannel extends R4Page {
 		return this.store.followers?.map((c) => c.slug).includes(this.config.selectedSlug)
 	}
 
-	// Set channel from the slug in the URL.
+	// Set channel from the config or URL params.
 	async setChannel() {
 		const slug = this.config.singleChannel && this.config.selectedSlug ? this.config.selectedSlug : this.params.slug
 


### PR DESCRIPTION
app wasn't rendering in single-channel mode, because `refreshUserData()` method was overwriting the `selectedChannel` attr.