### PR TITLE
Refactor with BaseQuery class

### DIFF
--- a/src/components/r4-supabase-filter-search.js
+++ b/src/components/r4-supabase-filter-search.js
@@ -36,6 +36,10 @@ export default class R4SupabaseFilterSearch extends LitElement {
 		)
 	}
 
+	// extractSearchFilterValue(filter) {
+	// 	return filter?.value.split(':')[0].split("'")[1]
+	// }
+
 	// Disable shadow DOM
 	createRenderRoot() {
 		return this

--- a/src/components/r4-supabase-query.js
+++ b/src/components/r4-supabase-query.js
@@ -30,7 +30,7 @@ export default class R4SupabaseQuery extends LitElement {
 		return Math.round(count / limit) + 1
 	}
 
-	/** @type {import('../libs/query-page.js').R4Query} */
+	/** @type {import('../pages/base-query.js').R4Query} */
 	get query() {
 		return urlUtils.removeEmptyKeys({
 			table: this.table,

--- a/src/data/routes-cms.json
+++ b/src/data/routes-cms.json
@@ -9,7 +9,6 @@
 	{"path": "/map", "page": "map"},
 	{"path": "/search", "page": "search"},
 	{"path": "/about", "page": "about"},
-	{"path": "/playground/:color", "page": "playground"},
 	{"path": "/:slug", "page": "channel"},
 	{"path": "/:slug/feed", "page": "channel-feed"},
 	{"path": "/:slug/update", "page": "channel-update"},

--- a/src/index.css
+++ b/src/index.css
@@ -358,8 +358,13 @@ r4-page-map r4-supabase-query fieldset[name='ascending'] {
 /* Hide table+select from /explore and tracks pages */
 r4-page-explore r4-supabase-select,
 r4-page-channel r4-supabase-select,
-r4-page-channel-tracks r4-supabase-select,
-r4-page-channel r4-supabase-query {
+r4-page-channel-tracks r4-supabase-select {
+	display: none;
+}
+
+/* Hide query ui on /:slug page */
+r4-page-channel menu:has(r4-supabase-filter-search),
+r4-page-channel details:has(r4-supabase-query) {
 	display: none;
 }
 

--- a/src/libs/browse.js
+++ b/src/libs/browse.js
@@ -45,7 +45,7 @@ export const supabaseOperators = Object.keys(supabaseOperatorsTable)
  * browse the list (of db table) like it is paginated;
  * (query params ->) components-attributes -> supbase-query
  * this does not render the list, just browses it
- * @param {import('./query-page.js').R4Query} props
+ * @param {import('../pages/base-query.js').R4Query} props
  */
 export async function browse(props) {
 	const {table, select, filters, orderBy, order, page = 1, limit = 1} = props

--- a/src/libs/url-utils.js
+++ b/src/libs/url-utils.js
@@ -57,11 +57,15 @@ function removeEmptyKeys(obj) {
 		Object.entries(obj).filter(([, value]) => {
 			// if (Array.isArray(value)) return value.length
 			return !!value
-		})
+		}),
 	)
 }
 
-// Create a `R4Query` from URLSearchParams.
+/**
+ * Create a `R4Query` from URLSearchParams
+ * @param {URLSearchParams} searchParams
+ * @returns {import("../pages/base-query").R4Query}
+ */
 export function getQueryFromUrl(searchParams) {
 	return removeEmptyKeys({
 		search: searchParams.get('search'),
@@ -72,7 +76,7 @@ export function getQueryFromUrl(searchParams) {
 		// Either as ?filter={}&filter={}
 		// filters: searchParams.getAll('filter').map(x => JSON.parse(x)),
 		// ... or filters=[{}, {}]
-		filters: JSON.parse(searchParams.get('filters'))
+		filters: JSON.parse(searchParams.get('filters')),
 	})
 }
 
@@ -83,11 +87,6 @@ export function createSearchFilter(search) {
 		value: `'${search}':*`,
 	}
 }
-
-// extractSearchFilterValue(filter) {
-// 	const search = filter?.value.split(':')[0].split("'")[1]
-// 	return search
-// }
 
 export default {
 	setSearchParams,

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -68,8 +68,6 @@ export default class BaseChannel extends BaseQuery {
 		// No need to set again if channel the same channel is loaded.
 		if (this.channel?.slug === slug) return
 
-		console.log('fetching channel')
-
 		const {data, error} = await sdk.channels.readChannel(slug)
 		this.canEdit = await sdk.channels.canEditChannel(slug)
 

--- a/src/pages/base-channel.js
+++ b/src/pages/base-channel.js
@@ -1,19 +1,22 @@
 import {html} from 'lit'
 import {sdk} from '../libs/sdk.js'
-import R4Page from '../components/r4-page.js'
-import urlUtils from '../libs/url-utils.js'
+import BaseQuery from './base-query.js'
 
 // Base class to extend from
-export default class BaseChannel extends R4Page {
+export default class BaseChannel extends BaseQuery {
 	static properties = {
 		channel: {type: Object, state: true},
-		tracks: {type: Array, state: true},
 		channelError: {type: Object, state: true},
 		canEdit: {type: Boolean, state: true},
 		alreadyFollowing: {type: Boolean, state: true},
 		followsYou: {type: Boolean, state: true},
 		isFirebaseChannel: {type: Boolean, state: true},
-		query: {type: Object, state: true},
+
+		// from BaseQuery
+		count: {type: Number},
+		data: {type: Array},
+		query: {type: Object},
+
 		// from router
 		params: {type: Object, state: true},
 		store: {type: Object, state: true},
@@ -21,14 +24,8 @@ export default class BaseChannel extends R4Page {
 		searchParams: {type: Object, state: true},
 	}
 
-	constructor() {
-		super()
-	}
-
 	async connectedCallback() {
 		if (!this.channel) await this.setChannel()
-		// Collect relevant params from the URLSearchParams.
-		this.query = urlUtils.getQueryFromUrl(this.searchParams)
 		super.connectedCallback()
 	}
 

--- a/src/pages/base-channels.js
+++ b/src/pages/base-channels.js
@@ -1,133 +1,28 @@
-import {html} from 'lit'
-import {browse} from '../libs/browse'
-import urlUtils from '../libs/url-utils'
-import R4Page from '../components/r4-page.js'
-import debounce from 'lodash.debounce'
+import BaseQuery from './base-query.js'
 
-export default class BaseChannels extends R4Page {
+export default class BaseChannels extends BaseQuery {
 	static properties = {
 		// from router
 		config: {type: Object},
 		searchParams: {type: Object, state: true},
-
-		channels: {type: Array, state: true},
-		query: {type: Object, state: true},
+		// from BaseQuery
 		count: {type: Number},
+		data: {type: Array},
+		query: {type: Object},
 	}
 
 	constructor() {
 		super()
-		this.debouncedSetChannels = debounce(() => this.setChannels(), 400, {leading: true, trailing: true})
-	}
-
-	connectedCallback() {
-		// Collect relevant params from the URLSearchParams.
-		this.query = urlUtils.getQueryFromUrl(this.searchParams)
-		super.connectedCallback()
+		this.query = {
+			table: 'channels',
+		}
 	}
 
 	get channelOrigin() {
 		return `${this.config.href}/{{slug}}`
 	}
 
-	get defaultFilters() {
-		return []
-	}
-
-	// Here you can add modify the query before it is passed to browse().
-	get queryWithDefaults() {
-		const q = {...this.query}
-		if (q.filters?.length) {
-			q.filters = [...q.filters, ...this.defaultFilters]
-		} else {
-			q.filters = this.defaultFilters
-		}
-		if (this.query.search) {
-			if (!q.filters) q.filters = []
-			q.filters = [...q.filters, urlUtils.createSearchFilter(this.query.search)]
-		}
-		return q
-	}
-
-	async setChannels() {
-		const res = await browse(this.queryWithDefaults)
-		if (res.error) {
-			console.log('error browsing channels', res.error)
-			// @todo "range not satisfiable" -> reset pagination
-			// if (res.error.code === 'PGRST103') {}
-		}
-		this.count = res.count
-		this.channels = res.data
-	}
-
-	onQuery(event) {
-		event.preventDefault()
-		console.log('@onQuery', event.detail)
-		this.setQuery(event.detail, ['table', 'select'])
-	}
-
-	onSearch(event) {
-		event.preventDefault()
-		const {search} = event.detail
-		this.setQuery({...this.query, search}, ['page', 'limit', 'order', 'orderBy'])
-	}
-
-	clearFilters() {
-		this.setQuery({...this.query, filters: []})
-	}
-
-	// Also updates URL params and reloads data.
-	setQuery(query, excludeList) {
-		this.query = query
-		urlUtils.setSearchParams(query, {excludeList})
-		this.debouncedSetChannels()
-	}
-
 	renderHeader() {
-		return [this.renderMenu(), this.renderQuery()]
-	}
-
-	renderQueryFiltersSummary() {
-		const filtersLen = this.query?.filters?.length
-		return filtersLen ? html`<button @click=${this.clearFilters}>Clear ${filtersLen}</button>` : null
-	}
-
-	renderMenu() {
-		return html`
-			<menu>
-				<li>
-					<r4-supabase-filter-search
-						search=${this.query?.search}
-						placeholder="channels"
-						@input=${this.onSearch}
-					></r4-supabase-filter-search>
-				</li>
-				<li>${this.count === 0 ? 0 : this.count || '…'} radio channels</li>
-			</menu>
-		`
-	}
-
-	renderQuery() {
-		return html`
-			<details>
-				<summary>Filters ${this.renderQueryFiltersSummary()}</summary>
-				<r4-supabase-query
-					table="channels"
-					.filters=${this.query?.filters}
-					order-by=${this.query?.orderBy}
-					order=${this.query?.order}
-					search=${this.query?.search}
-					page=${this.query?.page}
-					limit=${this.query?.limit}
-					count=${this.count}
-					@query=${this.onQuery}
-				></r4-supabase-query>
-			</details>
-		`
-	}
-
-	renderMain() {
-		// use this.channels
-		return html``
+		return this.renderQuery()
 	}
 }

--- a/src/pages/base-query.js
+++ b/src/pages/base-query.js
@@ -1,0 +1,157 @@
+import {html} from 'lit'
+import debounce from 'lodash.debounce'
+import urlUtils from '../libs/url-utils.js'
+import {browse} from '../libs/browse.js'
+import R4Page from '../components/r4-page.js'
+
+// This is not in use anywhere.
+// It is a sketch for later.
+
+/**
+ * @typedef {object} R4Query
+ * @prop {string} [table] - table name
+ * @prop {string} [select] - sql query to select columns
+ * @prop {string} [search] - search query
+ * @prop {R4Filter[]} [filters] - array of filters
+ * @prop {string} [orderBy] - column name to order by
+ * @prop {string} [order] - 'asc' or 'desc'
+ * @prop {{ascending: boolean}} [orderConfig] - used internally to keep track of the order and respect foreign tables
+ * @prop {number} [page] - page number
+ * @prop {number} [limit] - items per page
+ */
+
+/**
+ * @typedef {object} R4Filter
+ * @prop {string} column - column name
+ * @prop {string} operator - operator
+ * @prop {string} value - value
+ */
+
+/**
+ * Adds all the neccessary things to query the database with search, filters, ordering and pagination.
+ */
+export default class BaseQuery extends R4Page {
+	static get properties() {
+		return {
+			count: {type: Number},
+			data: {type: Array},
+			query: {type: Object},
+		}
+	}
+
+	constructor() {
+		super()
+
+		/** The amount of rows returned by fetchData */
+		this.count = 0
+
+		/** The latest data from fetchData */
+		this.data = []
+
+		/** @type {R4Query} */
+		this.query = {}
+
+		/** A debounced version of fetchData() */
+		this.debouncedFetchData = debounce(() => this.fetchData(), 400, {leading: false, trailing: true})
+	}
+
+	connectedCallback() {
+		// As soon as the DOM is ready, read the URL query params
+		this.query = {...this.query, ...urlUtils.getQueryFromUrl(new URLSearchParams(location.search))}
+		super.connectedCallback()
+	}
+
+	/**
+	 * @type {R4Filter[]}
+	 * This is a getter so we can access class properties like `this.slug` when accessed.
+	 */
+	get defaultFilters() {
+		return []
+	}
+
+	/**
+	 * Essentially this.query + this.defaultFilters
+	 * This exists in order to apply query changes that won't appear in the UI.
+	 * @returns {R4Query}
+	 */
+	get browseQuery() {
+		const q = {...this.query}
+		// Apply default filters if there are some.
+		if (q.filters?.length) {
+			q.filters = [...q.filters]
+		} else {
+			q.filters = this.defaultFilters
+		}
+		// Apply search filter if there is a search query.
+		if (this.query.search) {
+			if (!q.filters) q.filters = []
+			q.filters = [...q.filters, urlUtils.createSearchFilter(this.query.search)]
+		}
+		return q
+	}
+
+	async fetchData() {
+		const res = await browse(this.browseQuery)
+		if (res.error) console.log('error fetching data', res)
+		this.count = res.count
+		this.data = res.data
+	}
+
+	onQuery(event) {
+		event.preventDefault()
+		console.log('got it!', event.detail)
+		this.query = event.detail
+		urlUtils.setSearchParams(event.detail)
+		this.debouncedFetchData()
+	}
+
+	onSearch(event) {
+		event.preventDefault()
+		const {search} = event.detail
+		this.query.search = search
+		urlUtils.setSearchParams({search}, {includeList: ['search']}) // only update "search" param
+		this.debouncedFetchData()
+	}
+
+	clearFilters() {
+		this.setQuery({...this.query, filters: []})
+	}
+
+	// Just a shortcut when no extra logic is needed. Also updates URL params and reloads data.
+	setQuery(query) {
+		this.query = query
+		urlUtils.setSearchParams(this.query)
+		this.debouncedFetchData()
+	}
+
+	renderQuery() {
+		const filtersLen = this.query?.filters?.length
+		return html`
+			<menu>
+				<li>
+					<r4-supabase-filter-search
+						search=${this.query?.search}
+						placeholder=${this.count + ' rows'}
+						@input=${this.onSearch}
+					></r4-supabase-filter-search>
+				</li>
+			</menu>
+			<details open="true">
+				<summary>
+					Filters ${filtersLen ? html`<button @click=${this.clearFilters}>Clear ${filtersLen}</button>` : null}
+				</summary>
+				<r4-supabase-query
+					table=${this.query?.table}
+					.filters=${this.query?.filters}
+					order-by=${this.query?.orderBy}
+					order=${this.query?.order}
+					search=${this.query?.search}
+					page=${this.query?.page}
+					limit=${this.query?.limit}
+					count=${this.count}
+					@query=${this.onQuery}
+				></r4-supabase-query>
+			</details>
+		`
+	}
+}

--- a/src/pages/base-query.js
+++ b/src/pages/base-query.js
@@ -99,7 +99,6 @@ export default class BaseQuery extends R4Page {
 
 	onQuery(event) {
 		event.preventDefault()
-		console.log('got it!', event.detail)
 		this.query = event.detail
 		urlUtils.setSearchParams(event.detail)
 		this.debouncedFetchData()

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,12 +12,12 @@ import R4PageHome from './r4-page-home.js'
 import R4PageMap from './r4-page-map.js'
 import R4PageSearch from './r4-page-search.js'
 import R4PageNew from './r4-page-new.js'
-import R4PageSettings from './r4-page-settings'
+import R4PageSettings from './r4-page-settings.js'
 import R4PageSign from './r4-page-sign.js'
 import R4PageChannelTrack from './r4-page-channel-track'
 import R4PageTrackUpdate from './r4-page-track-update.js'
 import R4PageTrackDelete from './r4-page-track-delete.js'
-import R4PageChannelTracks from './r4-page-channel-tracks'
+import R4PageChannelTracks from './r4-page-channel-tracks.js'
 
 customElements.define('r4-page-about', R4PageAbout)
 customElements.define('r4-page-sign', R4PageSign)

--- a/src/pages/r4-page-channel-tracks.js
+++ b/src/pages/r4-page-channel-tracks.js
@@ -40,7 +40,7 @@ export default class R4PageChannelTracks extends BaseChannel {
 		if (this.channelError) {
 			return this.renderNoPage()
 		} else {
-			return this.renderQuery()
+			return [this.renderTracksMenu(), this.renderQuery()]
 		}
 	}
 

--- a/src/pages/r4-page-channel-tracks.js
+++ b/src/pages/r4-page-channel-tracks.js
@@ -1,83 +1,46 @@
 import {html} from 'lit'
 import {repeat} from 'lit/directives/repeat.js'
 import BaseChannel from './base-channel'
-import urlUtils from '../libs/url-utils.js'
-import {browse} from '../libs/browse.js'
-import debounce from 'lodash.debounce'
 
 export default class R4PageChannelTracks extends BaseChannel {
 	static properties = {
-		// from router
-		config: {type: Object},
-		searchParams: {type: Object, state: true},
-		// query related
-		tracks: {type: Array, state: true},
-		query: {type: Object, state: true},
+		// from BaseChannel
+		channel: {type: Object, state: true},
+		channelError: {type: Object, state: true},
+		canEdit: {type: Boolean, state: true},
+		alreadyFollowing: {type: Boolean, state: true},
+		followsYou: {type: Boolean, state: true},
+		isFirebaseChannel: {type: Boolean, state: true},
+		// from BaseQuery
 		count: {type: Number},
+		data: {type: Array},
+		query: {type: Object},
+		// from router
+		params: {type: Object, state: true},
+		store: {type: Object, state: true},
+		config: {type: Object, state: true},
+		searchParams: {type: Object, state: true},
 		// other
 		href: {type: String},
 		origin: {type: String},
-	}
-
-	constructor() {
-		super()
-		this.debouncedSetTracks = debounce(() => this.setTracks(), 400, {leading: true, trailing: true})
 	}
 
 	get defaultFilters() {
 		return [{operator: 'eq', column: 'slug', value: this.slug}]
 	}
 
-	// Here you can add modify the query before it is passed to browse()
-	get queryWithDefaults() {
-		const q = {...this.query}
-		if (q.filters?.length) {
-			q.filters = [...q.filters, ...this.defaultFilters]
-		} else {
-			q.filters = this.defaultFilters
+	constructor() {
+		super()
+		this.query = {
+			table: 'channel_tracks',
 		}
-		if (this.query.search) {
-			if (!q.filters) q.filters = []
-			q.filters = [...q.filters, urlUtils.createSearchFilter(this.query.search)]
-		}
-		return q
-	}
-
-	async onQuery(event) {
-		event.preventDefault()
-		console.log('@onQuery -> update url + fetch', event.detail)
-		this.query = event.detail
-		urlUtils.setSearchParams(event.detail)
-		this.debouncedSetTracks()
-	}
-
-	async onSearch(event) {
-		event.preventDefault()
-		const {search} = event.detail
-		console.log('@onSearch -> update url + fetch', search)
-		this.query.search = search
-		urlUtils.setSearchParams({search}, {includeList: ['search']})
-		this.debouncedSetTracks()
-	}
-
-	async setTracks() {
-		const res = await browse(this.queryWithDefaults)
-		if (res.error) {
-			console.log('error browsing tracks')
-			if (res.error.code === 'PGRST103') {
-				// @todo "range not satisfiable" -> reset pagination
-				// if (res.error.code === 'PGRST103') {}
-			}
-		}
-		this.count = res.count
-		this.tracks = res.data
 	}
 
 	renderHeader() {
 		if (this.channelError) {
 			return this.renderNoPage()
 		} else {
-			return [this.renderTracksMenu(), this.renderTracksQuery()]
+			return this.renderQuery()
 		}
 	}
 
@@ -88,7 +51,7 @@ export default class R4PageChannelTracks extends BaseChannel {
 	}
 
 	renderTracksList() {
-		if (this.tracks?.length) {
+		if (this.data?.length) {
 			return html` <r4-list> ${this.renderListItems()} </r4-list> `
 		} else {
 			return html`
@@ -101,7 +64,7 @@ export default class R4PageChannelTracks extends BaseChannel {
 
 	renderListItems() {
 		return repeat(
-			this.tracks,
+			this.data,
 			(t) => t.id,
 			(t) => html`
 				<r4-list-item>
@@ -118,43 +81,8 @@ export default class R4PageChannelTracks extends BaseChannel {
 		)
 	}
 
-	renderTracksQuery() {
-		return html`
-			<details open="true">
-				<summary>Filters ${this.renderQueryFiltersSummary()}</summary>
-				<r4-supabase-query
-					table="channel_tracks"
-					.filters=${this.query?.filters}
-					order-by=${this.query?.orderBy}
-					order=${this.query?.order}
-					search=${this.query?.search}
-					page=${this.query?.page}
-					limit=${this.query?.limit}
-					count=${this.count}
-					@query=${this.onQuery}
-				></r4-supabase-query>
-			</details>
-		`
-	}
-
-	renderQueryFiltersSummary() {
-		const filtersLen = this.query?.filters?.length
-		return filtersLen ? html`<button @click=${this.clearFilters}>Clear ${filtersLen}</button>` : null
-	}
-
-	clearFilters() {
-		this.setQuery({...this.query, filters: []})
-	}
-
-	// Also updates URL params and reloads data.
-	setQuery(query, excludeList) {
-		this.query = query
-		urlUtils.setSearchParams(query, excludeList)
-		this.debouncedSetTracks()
-	}
-
 	renderTracksMenu() {
-		if (!this.tracks) return null
+		if (!this.data) return null
 		return html`
 			<menu>
 				<li><a href=${this.channelOrigin}>@${this.slug}</a></li>
@@ -168,7 +96,7 @@ export default class R4PageChannelTracks extends BaseChannel {
 				</li>
 				<li>
 					<r4-button-play
-						.tracks=${this.tracks}
+						.tracks=${this.data}
 						.channel=${this.channel}
 						.filters=${this.filters}
 						label="Play results"

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -1,31 +1,28 @@
 import {html} from 'lit'
 import {repeat} from 'lit/directives/repeat.js'
 import BaseChannel from './base-channel'
-import {browse} from '../libs/browse'
 
 export default class R4PageChannel extends BaseChannel {
+	constructor() {
+		super()
+		this.query = {
+			table: 'channel_tracks',
+			orderBy: 'created_at',
+			order: 'desc',
+			page: 1,
+			limit: 8
+		}
+	}
 	async willUpdate(changedProperties) {
 		await super.willUpdate(changedProperties)
 		if (changedProperties.has('channel')) {
 			console.log('fetching tracks because channel changed')
-			await this.setTracks()
+			await this.fetchData()
 		}
 	}
 
-	get queryWithDefaults() {
-		return {
-			table: 'channel_tracks',
-			select: '*',
-			filters: [{operator: 'eq', column: 'slug', value: this.channel?.slug}],
-			orderBy: 'created_at',
-			order: 'desc',
-			page: 1,
-			limit: 8,
-		}
-	}
-
-	async setTracks() {
-		this.tracks = (await browse(this.queryWithDefaults)).data
+	get defaultFilters() {
+		return [{operator: 'eq', column: 'slug', value: this.channel?.slug}]
 	}
 
 	renderMain() {
@@ -34,21 +31,22 @@ export default class R4PageChannel extends BaseChannel {
 		}
 		// if (this.channelError) {}
 		if (this.channel) {
-			return html` <section>${this.renderTracksList()}</section> `
+			return html`
+				<section>${this.renderQuery()}</section>
+				<section>${this.renderTracksList()}</section> `
 		}
 	}
 
 	renderTracksList() {
-		if (!this.tracks) return null
+		if (!this.data) return null
 		return html`
 			<r4-list>
 				${repeat(
-					this.tracks,
+					this.data,
 					(t) => t.id,
 					(t) => this.renderTrackItem(t),
 				)}
 			</r4-list>
-			<r4-supabase-query table="channel_tracks" order=${this.searchParams.get('order')}></r4-supabase-query>
 		`
 	}
 

--- a/src/pages/r4-page-channel.js
+++ b/src/pages/r4-page-channel.js
@@ -7,17 +7,7 @@ export default class R4PageChannel extends BaseChannel {
 		super()
 		this.query = {
 			table: 'channel_tracks',
-			orderBy: 'created_at',
-			order: 'desc',
-			page: 1,
 			limit: 8
-		}
-	}
-	async willUpdate(changedProperties) {
-		await super.willUpdate(changedProperties)
-		if (changedProperties.has('channel')) {
-			console.log('fetching tracks because channel changed')
-			await this.fetchData()
 		}
 	}
 

--- a/src/pages/r4-page-explore.js
+++ b/src/pages/r4-page-explore.js
@@ -4,7 +4,7 @@ import BaseChannels from './base-channels.js'
 
 export default class R4PageExplore extends BaseChannels {
 	renderMain() {
-		if (this.channels) {
+		if (this.data) {
 			return html` <r4-list> ${this.renderListItems()} </r4-list> `
 		} else {
 			return html` No channels yet.`
@@ -13,7 +13,7 @@ export default class R4PageExplore extends BaseChannels {
 
 	renderListItems() {
 		return repeat(
-			this.channels || [],
+			this.data || [],
 			(c) => c.id,
 			(c) => html`
 				<r4-list-item>


### PR DESCRIPTION
I know we said we don't want more classes extending each other, but here is a try anyway to try and visualize the effects of it.

This avoids quite a bit of "complicated" logic being duplicated across pages and components, and now there's a clear path to follow when a page wants the query stuff.

- no longer have to deal with events
- don't need to know about `r4-supabase-query` and `r4-supabase-filter-search`

Any component can now extend `BaseQuery` to get all the query goodness ready to go. Here's how:

- `class MyComponent extends BaseQuery`
- set `this.query = { /* defaults */}` inside the constructor
- somewhere in your `render()` call `${this.renderQuery()}` to insert the filter search + query ui

Not sure this is the way, happy to hear any feedback. Now all the logic is basically inside these three, which could also be consolidated:

- libs/browse.js
- libs/url-utils.js
- components/base-query.js (uses r4-supabase-query and search filters)