### PR TITLE
Reset form state after submit

### DIFF
--- a/src/components/r4-form.js
+++ b/src/components/r4-form.js
@@ -292,6 +292,8 @@ export default class R4Form extends HTMLElement {
 	resetForm() {
 		if (this.$form) {
 			this.$form.reset()
+			this.state.title = ''
+			this.state.url = ''
 		}
 	}
 }


### PR DESCRIPTION
A fix for https://github.com/radio4000/components/issues/181

I tested on http://localhost:4000/examples/r4-track-create. The issue was in resetting the form "state" after submit. We did `this.$form.reset()`, but this only clears the values of the input fields. It doesn't touch internal state. So the URL-auto-filler thought it had a title, and wouldn't request a new one.

This PR properly clears the url + title after submit.